### PR TITLE
feat[JREUtils] automatically add a JVM arguemnt to disable Sodium's issue 2561 check

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -209,7 +209,7 @@ public final class Tools {
      * @param gameDir current game directory
      * @return whether sodium or a sodium-based mod is installed
      */
-    private static boolean hasSodium(File gameDir) {
+    public static boolean hasSodium(File gameDir) {
         File modsDir = new File(gameDir, "mods");
         File[] mods = modsDir.listFiles(file -> file.isFile() && file.getName().endsWith(".jar"));
         if(mods == null) return false;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -209,7 +209,7 @@ public final class Tools {
      * @param gameDir current game directory
      * @return whether sodium or a sodium-based mod is installed
      */
-    public static boolean hasSodium(File gameDir) {
+    private static boolean hasSodium(File gameDir) {
         File modsDir = new File(gameDir, "mods");
         File[] mods = modsDir.listFiles(file -> file.isFile() && file.getName().endsWith(".jar"));
         if(mods == null) return false;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -300,8 +300,6 @@ public class JREUtils {
         purgeArg(userArgs, "-Dorg.lwjgl.freetype.libname");
         // Overridden by us to specify the exact number of cores that the android system has
         purgeArg(userArgs, "-XX:ActiveProcessorCount");
-        // This will be automatically added if the launcher detects Sodium
-        purgeArg(userArgs,"-Dsodium.checks.issue2561=false");
 
         //Add automatically generated args
         userArgs.add("-Xms" + LauncherPreferences.PREF_RAM_ALLOCATION + "M");

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -315,7 +315,7 @@ public class JREUtils {
         // Some phones are not using the right number of cores, fix that
         userArgs.add("-XX:ActiveProcessorCount=" + java.lang.Runtime.getRuntime().availableProcessors());
         // Disable Sodium's LWJGL check to prevent a crash
-        if(Tools.hasSodium(gameDirectory)) userArgs.add("-Dsodium.checks.issue2561=false");
+        userArgs.add("-Dsodium.checks.issue2561=false");
         
         userArgs.addAll(JVMArgs);
         activity.runOnUiThread(() -> Toast.makeText(activity, activity.getString(R.string.autoram_info_msg,LauncherPreferences.PREF_RAM_ALLOCATION), Toast.LENGTH_SHORT).show());

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -300,6 +300,8 @@ public class JREUtils {
         purgeArg(userArgs, "-Dorg.lwjgl.freetype.libname");
         // Overridden by us to specify the exact number of cores that the android system has
         purgeArg(userArgs, "-XX:ActiveProcessorCount");
+        // This will be automatically added if the launcher detects Sodium
+        purgeArg(userArgs,"-Dsodium.checks.issue2561=false");
 
         //Add automatically generated args
         userArgs.add("-Xms" + LauncherPreferences.PREF_RAM_ALLOCATION + "M");
@@ -312,7 +314,9 @@ public class JREUtils {
 
         // Some phones are not using the right number of cores, fix that
         userArgs.add("-XX:ActiveProcessorCount=" + java.lang.Runtime.getRuntime().availableProcessors());
-
+        // Disable Sodium's LWJGL check to prevent a crash
+        if(Tools.hasSodium(gameDirectory)) userArgs.add("-Dsodium.checks.issue2561=false");
+        
         userArgs.addAll(JVMArgs);
         activity.runOnUiThread(() -> Toast.makeText(activity, activity.getString(R.string.autoram_info_msg,LauncherPreferences.PREF_RAM_ALLOCATION), Toast.LENGTH_SHORT).show());
         System.out.println(JVMArgs);


### PR DESCRIPTION
Sodium's issue 2561 check constantly crashes the game upon detecting "incompatible" LWJGL version. The users has to manually enter the JVM argument in order to launch the game with Sodium. This pr fixes it by automatically adding the argument if Sodium is detected. #3 is recommended with this pr for optimal experience

* ~~fix[tools] change visibility of hasSodium to public~~

* feat[JREUtils] add jvm argument to disable Sodium issue 2561 check