### PR TITLE
Feat[JREUtils]: override GL/GLSL version on zink

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -220,6 +220,12 @@ public class JREUtils {
                 envMap.put("LIBGL_ES", "3");
                 envMap.put("POJAVEXEC_EGL","libltw.so"); // Use ANGLE EGL
             }
+            if(LOCAL_RENDERER.equals("vulkan_zink")) {
+                // Explicitly tell Mesa to use 4.6/460 GLSL on Zink
+                // This fixes crash on some mobile drivers (Mali r32p1, so far)
+                envMap.put("MESA_GL_VERSION_OVERRIDE", "4.6");
+                envMap.put("MESA_GLSL_VERSION_OVERRIDE", "460");
+            }
         }
         if(LauncherPreferences.PREF_BIG_CORE_AFFINITY) envMap.put("POJAV_BIG_CORE_AFFINITY", "1");
         envMap.put("AWTSTUB_WIDTH", Integer.toString(CallbackBridge.windowWidth > 0 ? CallbackBridge.windowWidth : CallbackBridge.physicalWidth));


### PR DESCRIPTION
This should fix game crash on some devices with zink by overriding exported OpenGL version to 4.6
Tested on Mali G57/r32p1 by changing custom_env. Would be nice to check this on Adreno/Xclipse devices, but I don't have ones where tests can be done.

~~Marking this as draft as I have some ongoing issues with testing the app on my devices (not related to this PR)~~
Resolved