### PR TITLE
Allow resolutions beyond 100%

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -48,6 +48,7 @@ public class LauncherPreferences {
     public static boolean PREF_ARC_CAPES = false;
     public static boolean PREF_USE_ALTERNATE_SURFACE = true;
     public static boolean PREF_JAVA_SANDBOX = true;
+    public static boolean PREF_EXTENDED_RESOLUTION = false;
     public static float PREF_SCALE_FACTOR = 1f;
 
     public static boolean PREF_ENABLE_GYRO = false;
@@ -94,6 +95,7 @@ public class LauncherPreferences {
         PREF_ARC_CAPES = DEFAULT_PREF.getBoolean("arc_capes",false);
         PREF_USE_ALTERNATE_SURFACE = DEFAULT_PREF.getBoolean("alternate_surface", isDevicePowerful);
         PREF_JAVA_SANDBOX = DEFAULT_PREF.getBoolean("java_sandbox", true);
+        PREF_EXTENDED_RESOLUTION = DEFAULT_PREF.getBoolean("extendedResolution", false);
         PREF_SCALE_FACTOR = DEFAULT_PREF.getInt("resolutionRatio", findBestResolution(ctx, isDevicePowerful))/100f;
         PREF_ENABLE_GYRO = DEFAULT_PREF.getBoolean("enableGyro", false);
         PREF_GYRO_SENSITIVITY = ((float)DEFAULT_PREF.getInt("gyroSensitivity", 100))/100f;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceVideoFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceVideoFragment.java
@@ -29,8 +29,24 @@ public class LauncherPreferenceVideoFragment extends LauncherPreferenceFragment 
                 CustomSeekBarPreference.class);
         resolutionSeekbar.setSuffix(" %");
 
+        SwitchPreference extendedResolutionSwitch = requirePreference("extendedResolution",
+                SwitchPreference.class);
+        extendedResolutionSwitch.setOnPreferenceChangeListener((pref, value) -> {
+            if((boolean) value) {
+                resolutionSeekbar.setMaxKeepIncrement(250);
+            } else {
+                resolutionSeekbar.setMaxKeepIncrement(100);
+                if(LauncherPreferences.PREF_SCALE_FACTOR > 1) resolutionSeekbar.setValue(100);
+            }
+            return true;
+        });
+        extendedResolutionSwitch.setChecked(LauncherPreferences.PREF_EXTENDED_RESOLUTION);
+        if(extendedResolutionSwitch.isChecked()) {
+            resolutionSeekbar.setMaxKeepIncrement(250);
+        }
+
         // #724 bug fix
-        if (resolution < 25) {
+        if (resolution < 25 || !extendedResolutionSwitch.isChecked() && resolution > 100) {
             resolutionSeekbar.setValue(100);
         } else {
             resolutionSeekbar.setValue(resolution);

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -214,6 +214,8 @@
     <string name="preference_force_english_description">Allows you to see original strings, as intended by developers. Requires a restart.</string>
     <string name="preference_edit_controls_title">Edit custom controls</string>
     <string name="preference_edit_controls_summary">Tweak the control scheme to fit your needs.</string>
+    <string name="preference_enable_extended_resolution">Allow higher resolutions</string>
+    <string name="preference_enable_extended_resolution_description">Warning: This may cause performance issues!\nAllows selecting resolutions beyond 100%</string>
 
     <string name="preference_category_gyro_controls">Gyroscope controls</string>
     <string name="preference_category_virtual_mouse">Virtual mouse</string>

--- a/app_pojavlauncher/src/main/res/xml/pref_video.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_video.xml
@@ -20,6 +20,13 @@
             android:icon="@drawable/ic_px_viewport_expand"
             />
 
+        <SwitchPreference
+            android:title="@string/preference_enable_extended_resolution"
+            android:summary="@string/preference_enable_extended_resolution_description"
+            android:key="extendedResolution"
+            android:defaultValue="false"
+            />
+
         <net.kdt.pojavlaunch.prefs.CustomSeekBarPreference
             android:key="resolutionRatio"
             android:summary="@string/mcl_setting_subtitle_resolution_scaler"
@@ -29,7 +36,6 @@
             app2:min="@integer/resolution_seekbar_min"
             app2:seekBarIncrement="@integer/resolution_seekbar_increment"
             android:icon="@drawable/ic_px_resolution"
-            android:max="250"
             />
 
         <SwitchPreference

--- a/app_pojavlauncher/src/main/res/xml/pref_video.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_video.xml
@@ -29,6 +29,7 @@
             app2:min="@integer/resolution_seekbar_min"
             app2:seekBarIncrement="@integer/resolution_seekbar_increment"
             android:icon="@drawable/ic_px_resolution"
+            android:max="250"
             />
 
         <SwitchPreference


### PR DESCRIPTION
Allows selecting a resolution up to 250%
250 is not an arbitrary number, it is exactly 10 times the minimum resolution, which is why I chose it.

Use cases:
- Slightly higher resolutions may look better on some screens
- Taking big screenshots using F2 or rendering in high resolutions (ReplayMod) 
- Higher resolutions allow for smaller GUI scaling in the game
- Huge resolutions for the lols