### PR TITLE
Implement glfw cursor functions

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/CursorDrawable.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/CursorDrawable.java
@@ -9,10 +9,6 @@ import android.graphics.drawable.Drawable;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.util.Consumer;
-
-import java.util.HashSet;
-import java.util.Set;
 
 public class CursorDrawable extends Drawable {
     private Bitmap bitmap;
@@ -20,7 +16,6 @@ public class CursorDrawable extends Drawable {
     private int fallbackHeight;
     private int xHotspot;
     private int yHotspot;
-    private Set<Consumer<CursorDrawable>> listeners = new HashSet<>();
     private final int xHotspotFallback;
     private final int yHotspotFallback;
     private final Drawable fallback;
@@ -78,20 +73,6 @@ public class CursorDrawable extends Drawable {
         this.yHotspot = yHotspot;
     }
 
-    public void markDirty() {
-        for (Consumer<CursorDrawable> listener : this.listeners) {
-            listener.accept(this);
-        }
-    }
-
-    public void onChange(Consumer<CursorDrawable> consumer) {
-        this.listeners.add(consumer);
-    }
-
-    public void removeChangeListener(Consumer<CursorDrawable> onCursorChange) {
-        this.listeners.remove(onCursorChange);
-    }
-
     @Override
     public void draw(@NonNull Canvas canvas) {
         if(this.bitmap == null) {
@@ -116,7 +97,7 @@ public class CursorDrawable extends Drawable {
     @Override
     public int getOpacity() {
         if(this.bitmap != null) {
-            return PixelFormat.UNKNOWN;
+            return PixelFormat.TRANSLUCENT;
         }
         return fallback.getOpacity();
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/CursorDrawable.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/CursorDrawable.java
@@ -5,22 +5,26 @@ import android.graphics.Canvas;
 import android.graphics.ColorFilter;
 import android.graphics.Paint;
 import android.graphics.PixelFormat;
-import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.Consumer;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class CursorDrawable extends Drawable {
     private Bitmap bitmap;
-    private Paint paint;
     private int fallbackWidth;
     private int fallbackHeight;
     private int xHotspot;
     private int yHotspot;
+    private Set<Consumer<CursorDrawable>> listeners = new HashSet<>();
     private final int xHotspotFallback;
     private final int yHotspotFallback;
     private final Drawable fallback;
+    private final Paint paint = new Paint();
 
     public CursorDrawable(Bitmap bitmap, Drawable fallback, int fallbackWidth, int fallbackHeight, int xHotspot, int yHotspot,
                           int xHotspotFallback, int yHotspotFallback) {
@@ -66,12 +70,34 @@ public class CursorDrawable extends Drawable {
         return yHotspot;
     }
 
+    public void setXHotspot(int xHotspot) {
+        this.xHotspot = xHotspot;
+    }
+
+    public void setYHotspot(int yHotspot) {
+        this.yHotspot = yHotspot;
+    }
+
+    public void markDirty() {
+        for (Consumer<CursorDrawable> listener : this.listeners) {
+            listener.accept(this);
+        }
+    }
+
+    public void onChange(Consumer<CursorDrawable> consumer) {
+        this.listeners.add(consumer);
+    }
+
+    public void removeChangeListener(Consumer<CursorDrawable> onCursorChange) {
+        this.listeners.remove(onCursorChange);
+    }
+
     @Override
     public void draw(@NonNull Canvas canvas) {
         if(this.bitmap == null) {
             fallback.draw(canvas);
         } else {
-            canvas.drawBitmap(bitmap, null, new Rect(), paint);
+            canvas.drawBitmap(bitmap, 0, 0, paint);
         }
     }
 
@@ -90,8 +116,14 @@ public class CursorDrawable extends Drawable {
     @Override
     public int getOpacity() {
         if(this.bitmap != null) {
-            return PixelFormat.TRANSPARENT;
+            return PixelFormat.UNKNOWN;
         }
         return fallback.getOpacity();
+    }
+
+    @Override
+    public void setBounds(int left, int top, int right, int bottom) {
+        super.setBounds(left, top, right, bottom);
+        fallback.setBounds(left, top, right, bottom);
     }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/CursorDrawable.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/CursorDrawable.java
@@ -1,0 +1,97 @@
+package net.kdt.pojavlaunch.customcontrols.mouse;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.ColorFilter;
+import android.graphics.Paint;
+import android.graphics.PixelFormat;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class CursorDrawable extends Drawable {
+    private Bitmap bitmap;
+    private Paint paint;
+    private int fallbackWidth;
+    private int fallbackHeight;
+    private int xHotspot;
+    private int yHotspot;
+    private final int xHotspotFallback;
+    private final int yHotspotFallback;
+    private final Drawable fallback;
+
+    public CursorDrawable(Bitmap bitmap, Drawable fallback, int fallbackWidth, int fallbackHeight, int xHotspot, int yHotspot,
+                          int xHotspotFallback, int yHotspotFallback) {
+        this.bitmap = bitmap;
+        this.fallback = fallback;
+        this.fallbackWidth = fallbackWidth;
+        this.fallbackHeight = fallbackHeight;
+        this.xHotspot = xHotspot;
+        this.yHotspot = yHotspot;
+        this.xHotspotFallback = xHotspotFallback;
+        this.yHotspotFallback = yHotspotFallback;
+    }
+
+    public Bitmap getBitmap() {
+        return bitmap;
+    }
+
+    public void setBitmap(Bitmap bitmap) {
+        this.bitmap = bitmap;
+    }
+
+    public Drawable getFallback() {
+        return fallback;
+    }
+
+    public int getWidth() {
+        if(bitmap == null) return fallbackWidth;
+        return bitmap.getWidth();
+    }
+
+    public int getHeight() {
+        if(bitmap == null) return fallbackHeight;
+        return bitmap.getHeight();
+    }
+
+    public int getXHotspot() {
+        if(bitmap == null) return xHotspotFallback;
+        return xHotspot;
+    }
+
+    public int getYHotspot() {
+        if(bitmap == null) return yHotspotFallback;
+        return yHotspot;
+    }
+
+    @Override
+    public void draw(@NonNull Canvas canvas) {
+        if(this.bitmap == null) {
+            fallback.draw(canvas);
+        } else {
+            canvas.drawBitmap(bitmap, null, new Rect(), paint);
+        }
+    }
+
+    @Override
+    public void setAlpha(int alpha) {
+        paint.setAlpha(alpha);
+        fallback.setAlpha(alpha);
+    }
+
+    @Override
+    public void setColorFilter(@Nullable ColorFilter colorFilter) {
+        paint.setColorFilter(colorFilter);
+        fallback.setColorFilter(colorFilter);
+    }
+
+    @Override
+    public int getOpacity() {
+        if(this.bitmap != null) {
+            return PixelFormat.TRANSPARENT;
+        }
+        return fallback.getOpacity();
+    }
+}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/Touchpad.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/Touchpad.java
@@ -12,6 +12,7 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.core.util.Consumer;
 
 import net.kdt.pojavlaunch.GrabListener;
 import git.artdeell.mojo.R;
@@ -28,6 +29,7 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
     /* Mouse pointer icon used by the touchpad */
     private CursorDrawable mMousePointerDrawable;
     private float mMouseX, mMouseY;
+    private final Consumer<CursorDrawable> onCursorChange = cursor->invalidate();
     public Touchpad(@NonNull Context context) {
         this(context, null);
     }
@@ -78,13 +80,16 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
 
     @Override
     protected void onDraw(Canvas canvas) {
-        canvas.translate(mMouseX - mMousePointerDrawable.getXHotspot(), mMouseY - mMousePointerDrawable.getYHotspot());
+        canvas.translate(mMouseX, mMouseY);
+        canvas.scale(LauncherPreferences.PREF_MOUSESCALE, LauncherPreferences.PREF_MOUSESCALE);
+        canvas.translate(-mMousePointerDrawable.getXHotspot(), -mMousePointerDrawable.getYHotspot());
         mMousePointerDrawable.draw(canvas);
     }
 
     private void init(){
         setupMouse(null);
         CallbackBridge.setCurrentCursorDrawable(mMousePointerDrawable);
+        mMousePointerDrawable.onChange(onCursorChange);
 
         setFocusable(false);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -136,6 +141,23 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
         _disable();
     }
 
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        if(mMousePointerDrawable != null) {
+            mMousePointerDrawable.onChange(onCursorChange);
+        }
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        if(mMousePointerDrawable != null) {
+            mMousePointerDrawable.removeChangeListener(onCursorChange);
+        }
+    }
+
+
     private void setupMouse(Bitmap bitmap) {
         // Setup mouse pointer
         mMousePointerDrawable = new CursorDrawable(
@@ -148,8 +170,8 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
         assert mMousePointerDrawable != null;
         mMousePointerDrawable.setBounds(
                 0, 0,
-                (int) (mMousePointerDrawable.getWidth() * LauncherPreferences.PREF_MOUSESCALE),
-                (int) (mMousePointerDrawable.getHeight() * LauncherPreferences.PREF_MOUSESCALE)
+                mMousePointerDrawable.getWidth(),
+                mMousePointerDrawable.getHeight()
         );
     }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/Touchpad.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/Touchpad.java
@@ -5,14 +5,15 @@ import static net.kdt.pojavlaunch.Tools.currentDisplayMetrics;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.os.SystemClock;
 import android.util.AttributeSet;
 import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.res.ResourcesCompat;
-import androidx.core.util.Consumer;
 
 import net.kdt.pojavlaunch.GrabListener;
 import git.artdeell.mojo.R;
@@ -29,7 +30,23 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
     /* Mouse pointer icon used by the touchpad */
     private CursorDrawable mMousePointerDrawable;
     private float mMouseX, mMouseY;
-    private final Consumer<CursorDrawable> onCursorChange = cursor->invalidate();
+    private final Drawable.Callback cursorDrawableCallback = new Drawable.Callback() {
+        @Override
+        public void invalidateDrawable(@NonNull Drawable drawable) {
+            invalidate();
+        }
+
+        @Override
+        public void scheduleDrawable(@NonNull Drawable drawable, @NonNull Runnable runnable, long l) {
+            postDelayed(runnable, l - SystemClock.uptimeMillis());
+        }
+
+        @Override
+        public void unscheduleDrawable(@NonNull Drawable drawable, @NonNull Runnable runnable) {
+            removeCallbacks(runnable);
+        }
+    };
+
     public Touchpad(@NonNull Context context) {
         this(context, null);
     }
@@ -89,7 +106,7 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
     private void init(){
         setupMouse(null);
         CallbackBridge.setCurrentCursorDrawable(mMousePointerDrawable);
-        mMousePointerDrawable.onChange(onCursorChange);
+        mMousePointerDrawable.setCallback(cursorDrawableCallback);
 
         setFocusable(false);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -145,7 +162,7 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
         if(mMousePointerDrawable != null) {
-            mMousePointerDrawable.onChange(onCursorChange);
+            mMousePointerDrawable.setCallback(cursorDrawableCallback);
         }
     }
 
@@ -153,7 +170,10 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         if(mMousePointerDrawable != null) {
-            mMousePointerDrawable.removeChangeListener(onCursorChange);
+            // if we do not detach the callback
+            // it may cause a memory leak due to the object
+            // storing an instance of this View
+            mMousePointerDrawable.setCallback(null);
         }
     }
 
@@ -165,9 +185,6 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
                 ResourcesCompat.getDrawable(getResources(), R.drawable.ic_mouse_pointer, getContext().getTheme()),
                 36, 54, 0, 0, 1, 1
         );
-        // For some reason it's annotated as Nullable even though it doesn't seem to actually
-        // ever return null
-        assert mMousePointerDrawable != null;
         mMousePointerDrawable.setBounds(
                 0, 0,
                 mMousePointerDrawable.getWidth(),

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/Touchpad.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/Touchpad.java
@@ -3,8 +3,8 @@ package net.kdt.pojavlaunch.customcontrols.mouse;
 import static net.kdt.pojavlaunch.Tools.currentDisplayMetrics;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
@@ -26,7 +26,7 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
     /* Whether the Touchpad should be displayed */
     private boolean mDisplayState;
     /* Mouse pointer icon used by the touchpad */
-    private Drawable mMousePointerDrawable;
+    private CursorDrawable mMousePointerDrawable;
     private float mMouseX, mMouseY;
     public Touchpad(@NonNull Context context) {
         this(context, null);
@@ -78,21 +78,14 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
 
     @Override
     protected void onDraw(Canvas canvas) {
-        canvas.translate(mMouseX, mMouseY);
+        canvas.translate(mMouseX - mMousePointerDrawable.getXHotspot(), mMouseY - mMousePointerDrawable.getYHotspot());
         mMousePointerDrawable.draw(canvas);
     }
 
     private void init(){
-        // Setup mouse pointer
-        mMousePointerDrawable = ResourcesCompat.getDrawable(getResources(), R.drawable.ic_mouse_pointer, getContext().getTheme());
-        // For some reason it's annotated as Nullable even though it doesn't seem to actually
-        // ever return null
-        assert mMousePointerDrawable != null;
-        mMousePointerDrawable.setBounds(
-                0, 0,
-                (int) (36 * LauncherPreferences.PREF_MOUSESCALE),
-                (int) (54 * LauncherPreferences.PREF_MOUSESCALE)
-        );
+        setupMouse(null);
+        CallbackBridge.setCurrentCursorDrawable(mMousePointerDrawable);
+
         setFocusable(false);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             setDefaultFocusHighlightEnabled(false);
@@ -141,5 +134,22 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
         if(!mDisplayState) return;
         mDisplayState = false;
         _disable();
+    }
+
+    private void setupMouse(Bitmap bitmap) {
+        // Setup mouse pointer
+        mMousePointerDrawable = new CursorDrawable(
+                bitmap,
+                ResourcesCompat.getDrawable(getResources(), R.drawable.ic_mouse_pointer, getContext().getTheme()),
+                36, 54, 0, 0, 1, 1
+        );
+        // For some reason it's annotated as Nullable even though it doesn't seem to actually
+        // ever return null
+        assert mMousePointerDrawable != null;
+        mMousePointerDrawable.setBounds(
+                0, 0,
+                (int) (mMousePointerDrawable.getWidth() * LauncherPreferences.PREF_MOUSESCALE),
+                (int) (mMousePointerDrawable.getHeight() * LauncherPreferences.PREF_MOUSESCALE)
+        );
     }
 }

--- a/app_pojavlauncher/src/main/java/org/lwjgl/glfw/CallbackBridge.java
+++ b/app_pojavlauncher/src/main/java/org/lwjgl/glfw/CallbackBridge.java
@@ -235,7 +235,7 @@ public class CallbackBridge {
         sCurrentCursorDrawable.setBounds(0, 0, newWidth, newHeight);
         sCurrentCursorDrawable.setXHotspot(xHotspot);
         sCurrentCursorDrawable.setYHotspot(yHotspot);
-        sCurrentCursorDrawable.markDirty();
+        sCurrentCursorDrawable.invalidateSelf();
     }
 
     public static void addGrabListener(GrabListener listener) {

--- a/app_pojavlauncher/src/main/java/org/lwjgl/glfw/CallbackBridge.java
+++ b/app_pojavlauncher/src/main/java/org/lwjgl/glfw/CallbackBridge.java
@@ -221,13 +221,19 @@ public class CallbackBridge {
         int newWidth, newHeight;
         if(buffer != null) {
             if (bitmap == null || bitmap.getWidth() != width || bitmap.getHeight() != height) {
+                if (bitmap != null) {
+                    bitmap.recycle();
+                }
                 sCurrentCursorDrawable.setBitmap(bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888));
             }
             bitmap.copyPixelsFromBuffer(buffer);
             newWidth = width;
             newHeight = height;
         } else {
-            sCurrentCursorDrawable.setBitmap(null);
+            if (bitmap != null) {
+                bitmap.recycle();
+                sCurrentCursorDrawable.setBitmap(null);
+            }
             newWidth = sCurrentCursorDrawable.getWidth();
             newHeight = sCurrentCursorDrawable.getHeight();
         }

--- a/app_pojavlauncher/src/main/java/org/lwjgl/glfw/CallbackBridge.java
+++ b/app_pojavlauncher/src/main/java/org/lwjgl/glfw/CallbackBridge.java
@@ -40,7 +40,7 @@ public class CallbackBridge {
     public static final ByteBuffer sGamepadButtonBuffer;
     public static final FloatBuffer sGamepadAxisBuffer;
     public static boolean sGamepadDirectInput = false;
-    private static CursorDrawable sCurrentCursorDrawable;
+    @Nullable private static CursorDrawable sCurrentCursorDrawable;
 
     public static void putMouseEventWithCoords(int button, float x, float y) {
         putMouseEventWithCoords(button, true, x, y);
@@ -214,13 +214,28 @@ public class CallbackBridge {
 
     @SuppressWarnings("unused")
     @Keep
-    private static void onCursorStateUpdate(ByteBuffer buffer, int width, int height, int xHotspot, int yHotspot) {
+    private static void onCursorStateUpdate(@Nullable ByteBuffer buffer, int width, int height, int xHotspot, int yHotspot) {
+        if(sCurrentCursorDrawable == null) return;
         Bitmap bitmap = sCurrentCursorDrawable.getBitmap();
 
-        if(bitmap.getWidth() != width || bitmap.getHeight() != height) {
-            sCurrentCursorDrawable.setBitmap(bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888));
+        int newWidth, newHeight;
+        if(buffer != null) {
+            if (bitmap == null || bitmap.getWidth() != width || bitmap.getHeight() != height) {
+                sCurrentCursorDrawable.setBitmap(bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888));
+            }
+            bitmap.copyPixelsFromBuffer(buffer);
+            newWidth = width;
+            newHeight = height;
+        } else {
+            sCurrentCursorDrawable.setBitmap(null);
+            newWidth = sCurrentCursorDrawable.getWidth();
+            newHeight = sCurrentCursorDrawable.getHeight();
         }
-        bitmap.copyPixelsFromBuffer(buffer);
+
+        sCurrentCursorDrawable.setBounds(0, 0, newWidth, newHeight);
+        sCurrentCursorDrawable.setXHotspot(xHotspot);
+        sCurrentCursorDrawable.setYHotspot(yHotspot);
+        sCurrentCursorDrawable.markDirty();
     }
 
     public static void addGrabListener(GrabListener listener) {

--- a/app_pojavlauncher/src/main/java/org/lwjgl/glfw/CallbackBridge.java
+++ b/app_pojavlauncher/src/main/java/org/lwjgl/glfw/CallbackBridge.java
@@ -2,8 +2,10 @@ package org.lwjgl.glfw;
 
 import net.kdt.pojavlaunch.*;
 import net.kdt.pojavlaunch.customcontrols.gamepad.direct.DirectGamepadEnableHandler;
+import net.kdt.pojavlaunch.customcontrols.mouse.CursorDrawable;
 
 import android.content.*;
+import android.graphics.Bitmap;
 import android.util.Log;
 import android.view.Choreographer;
 
@@ -24,11 +26,11 @@ public class CallbackBridge {
     private static final ArrayList<GrabListener> grabListeners = new ArrayList<>();
     // Use a weak reference here to avoid possibly statically referencing a Context.
     private static @Nullable WeakReference<DirectGamepadEnableHandler> sDirectGamepadEnableHandler;
-    
+
     public static final int CLIPBOARD_COPY = 2000;
     public static final int CLIPBOARD_PASTE = 2001;
     public static final int CLIPBOARD_OPEN = 2002;
-    
+
     public static volatile int windowWidth, windowHeight;
     public static volatile int physicalWidth, physicalHeight;
     public static float mouseX, mouseY;
@@ -38,6 +40,7 @@ public class CallbackBridge {
     public static final ByteBuffer sGamepadButtonBuffer;
     public static final FloatBuffer sGamepadAxisBuffer;
     public static boolean sGamepadDirectInput = false;
+    private static CursorDrawable sCurrentCursorDrawable;
 
     public static void putMouseEventWithCoords(int button, float x, float y) {
         putMouseEventWithCoords(button, true, x, y);
@@ -177,6 +180,10 @@ public class CallbackBridge {
         }
     }
 
+    public static void setCurrentCursorDrawable(CursorDrawable sCurrentCursorDrawable) {
+        CallbackBridge.sCurrentCursorDrawable = sCurrentCursorDrawable;
+    }
+
     //Called from JRE side
     @SuppressWarnings("unused")
     @Keep
@@ -204,6 +211,18 @@ public class CallbackBridge {
         }, 16);
 
     }
+
+    @SuppressWarnings("unused")
+    @Keep
+    private static void onCursorStateUpdate(ByteBuffer buffer, int width, int height, int xHotspot, int yHotspot) {
+        Bitmap bitmap = sCurrentCursorDrawable.getBitmap();
+
+        if(bitmap.getWidth() != width || bitmap.getHeight() != height) {
+            sCurrentCursorDrawable.setBitmap(bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888));
+        }
+        bitmap.copyPixelsFromBuffer(buffer);
+    }
+
     public static void addGrabListener(GrabListener listener) {
         synchronized (grabListeners) {
             listener.onGrabState(isGrabbing);

--- a/app_pojavlauncher/src/main/jni/egl_bridge.c
+++ b/app_pojavlauncher/src/main/jni/egl_bridge.c
@@ -259,6 +259,11 @@ EXTERNAL_API void pojavSwapInterval(int interval) {
 
 EXTERNAL_API Cursor* pojavCreateCursor(GLFWImage* image, int xhot, int yhot) {
     Cursor* cursor = malloc(sizeof(Cursor));
+    if(cursor == NULL) {
+        printf("Failed to allocate cursor: %zu bytes\n", sizeof(Cursor));
+        return NULL;
+    }
+
     cursor->width = image->width;
     cursor->height = image->height;
     cursor->xHot = xhot;
@@ -269,7 +274,7 @@ EXTERNAL_API Cursor* pojavCreateCursor(GLFWImage* image, int xhot, int yhot) {
     uint8_t* dst = malloc(numPixels * 4);
 
     if(dst == NULL) {
-        printf("Failed to allocate cursor->image: %i bytes\n", numPixels * 4);
+        printf("Failed to allocate cursor->image: %zu bytes\n", numPixels * 4);
         free(cursor);
         return NULL;
     }
@@ -284,6 +289,10 @@ EXTERNAL_API Cursor* pojavCreateCursor(GLFWImage* image, int xhot, int yhot) {
             dst[i * 4 + 0] = 0;
             dst[i * 4 + 1] = 0;
             dst[i * 4 + 2] = 0;
+        } else if (a == 255) {
+            dst[i * 4 + 0] = r;
+            dst[i * 4 + 1] = g;
+            dst[i * 4 + 2] = b;
         } else {
             dst[i * 4 + 0] = (r * a) / 255;
             dst[i * 4 + 1] = (g * a) / 255;

--- a/app_pojavlauncher/src/main/jni/egl_bridge.c
+++ b/app_pojavlauncher/src/main/jni/egl_bridge.c
@@ -261,11 +261,37 @@ EXTERNAL_API Cursor* pojavCreateCursor(GLFWImage* image, int xhot, int yhot) {
     Cursor* cursor = malloc(sizeof(Cursor));
     cursor->width = image->width;
     cursor->height = image->height;
-    cursor->image = malloc(image->width * image->height * 4);
     cursor->xHot = xhot;
     cursor->yHot = yhot;
 
-    memcpy(cursor->image, image->pixels, image->width * image->height * 4);
+    uint8_t* src = (uint8_t*)image->pixels;
+    size_t numPixels = cursor->width * cursor->height;
+    uint8_t* dst = malloc(numPixels * 4);
+
+    if(dst == NULL) {
+        printf("Failed to allocate cursor->image: %i bytes", numPixels * 4);
+        return NULL;
+    }
+
+    for (size_t i = 0; i < numPixels; i++) {
+        uint8_t r = src[i * 4 + 0];
+        uint8_t g = src[i * 4 + 1];
+        uint8_t b = src[i * 4 + 2];
+        uint8_t a = src[i * 4 + 3];
+
+        if (a == 0) {
+            dst[i * 4 + 0] = 0;
+            dst[i * 4 + 1] = 0;
+            dst[i * 4 + 2] = 0;
+        } else {
+            dst[i * 4 + 0] = (r * a) / 255;
+            dst[i * 4 + 1] = (g * a) / 255;
+            dst[i * 4 + 2] = (b * a) / 255;
+        }
+        dst[i * 4 + 3] = a;
+    }
+
+    cursor->image = dst;
 
     return cursor;
 }
@@ -293,6 +319,7 @@ EXTERNAL_API void pojavDestroyCursor(Cursor* cursor) {
     if(pojav_environ->cursorState == cursor) {
         pojavSetCursor(0, NULL);
     }
+    free(cursor->image);
     free(cursor);
 }
 

--- a/app_pojavlauncher/src/main/jni/egl_bridge.c
+++ b/app_pojavlauncher/src/main/jni/egl_bridge.c
@@ -38,6 +38,14 @@
 // This means that you are forced to have this function/variable for ABI compatibility
 #define ABI_COMPAT __attribute__((unused))
 
+#define TRY_ATTACH_ENV(env_name, vm, error_message, then) JNIEnv* env_name;\
+do {                                                                       \
+    env_name = get_attached_env(vm);                                       \
+    if(env_name == NULL) {                                                 \
+        printf(error_message);                                             \
+        then                                                               \
+    }                                                                      \
+} while(0)
 
 struct PotatoBridge {
 
@@ -249,3 +257,27 @@ EXTERNAL_API void pojavSwapInterval(int interval) {
     br_swap_interval(interval);
 }
 
+EXTERNAL_API Cursor* pojavCreateCursor(GLFWImage* image, int xhot, int yhot) {
+    Cursor* cursor = malloc(sizeof(Cursor));
+    cursor->width = image->width;
+    cursor->height = image->height;
+    cursor->image = image->pixels;
+    cursor->xHot = xhot;
+    cursor->yHot = yhot;
+    return cursor;
+}
+
+EXTERNAL_API void pojavDestroyCursor(Cursor* cursor) {
+    if(pojav_environ->cursorState == cursor) {
+        pojav_environ->cursorState = NULL;
+    }
+    free(cursor);
+}
+
+EXTERNAL_API void pojavSetCursor(long window, Cursor* cursor) {
+    pojav_environ->cursorState = cursor;
+
+    TRY_ATTACH_ENV(env, pojav_environ->dalvikJavaVMPtr, "CallbackBridge.onCursorStateChange failed!\n", return;);
+    jobject buffer = (*env)->NewDirectByteBuffer(env, cursor->image, cursor->width * cursor->height);
+    (*env)->CallStaticVoidMethod(env, pojav_environ->method_onCursorStateChange, buffer, cursor->width, cursor->height, cursor->xHot, cursor->yHot);
+}

--- a/app_pojavlauncher/src/main/jni/egl_bridge.c
+++ b/app_pojavlauncher/src/main/jni/egl_bridge.c
@@ -269,7 +269,8 @@ EXTERNAL_API Cursor* pojavCreateCursor(GLFWImage* image, int xhot, int yhot) {
     uint8_t* dst = malloc(numPixels * 4);
 
     if(dst == NULL) {
-        printf("Failed to allocate cursor->image: %i bytes", numPixels * 4);
+        printf("Failed to allocate cursor->image: %i bytes\n", numPixels * 4);
+        free(cursor);
         return NULL;
     }
 
@@ -307,6 +308,7 @@ EXTERNAL_API void pojavSetCursor(long window, Cursor* cursor) {
     } else {
         jobject buffer = (*env)->NewDirectByteBuffer(env, cursor->image, cursor->width * cursor->height * 4);
         if(buffer == NULL) {
+            printf("Failed to create ByteBuffer for cursor image!\n");
             return;
         }
         (*env)->CallStaticVoidMethod(env, pojav_environ->bridgeClazz,

--- a/app_pojavlauncher/src/main/jni/egl_bridge.c
+++ b/app_pojavlauncher/src/main/jni/egl_bridge.c
@@ -261,23 +261,38 @@ EXTERNAL_API Cursor* pojavCreateCursor(GLFWImage* image, int xhot, int yhot) {
     Cursor* cursor = malloc(sizeof(Cursor));
     cursor->width = image->width;
     cursor->height = image->height;
-    cursor->image = image->pixels;
+    cursor->image = malloc(image->width * image->height * 4);
     cursor->xHot = xhot;
     cursor->yHot = yhot;
-    return cursor;
-}
 
-EXTERNAL_API void pojavDestroyCursor(Cursor* cursor) {
-    if(pojav_environ->cursorState == cursor) {
-        pojav_environ->cursorState = NULL;
-    }
-    free(cursor);
+    memcpy(cursor->image, image->pixels, image->width * image->height * 4);
+
+    return cursor;
 }
 
 EXTERNAL_API void pojavSetCursor(long window, Cursor* cursor) {
     pojav_environ->cursorState = cursor;
 
     TRY_ATTACH_ENV(env, pojav_environ->dalvikJavaVMPtr, "CallbackBridge.onCursorStateChange failed!\n", return;);
-    jobject buffer = (*env)->NewDirectByteBuffer(env, cursor->image, cursor->width * cursor->height);
-    (*env)->CallStaticVoidMethod(env, pojav_environ->method_onCursorStateChange, buffer, cursor->width, cursor->height, cursor->xHot, cursor->yHot);
+
+    if(cursor == NULL) {
+        (*env)->CallStaticVoidMethod(env, pojav_environ->bridgeClazz,
+                                     pojav_environ->method_onCursorStateChange, NULL, 0, 0, 0, 0);
+    } else {
+        jobject buffer = (*env)->NewDirectByteBuffer(env, cursor->image, cursor->width * cursor->height * 4);
+        if(buffer == NULL) {
+            return;
+        }
+        (*env)->CallStaticVoidMethod(env, pojav_environ->bridgeClazz,
+                                     pojav_environ->method_onCursorStateChange, buffer,
+                                     cursor->width, cursor->height, cursor->xHot, cursor->yHot);
+    }
 }
+
+EXTERNAL_API void pojavDestroyCursor(Cursor* cursor) {
+    if(pojav_environ->cursorState == cursor) {
+        pojavSetCursor(0, NULL);
+    }
+    free(cursor);
+}
+

--- a/app_pojavlauncher/src/main/jni/environ/environ.h
+++ b/app_pojavlauncher/src/main/jni/environ/environ.h
@@ -33,6 +33,20 @@ typedef struct  {
     float axes[6];
 } GLFWgamepadstate;
 
+typedef struct {
+    unsigned char* image;
+    int width;
+    int height;
+    int xHot;
+    int yHot;
+} Cursor;
+
+typedef struct {
+    int width;
+    int height;
+    unsigned char* pixels;
+} GLFWImage;
+
 struct pojav_environ_s {
     struct ANativeWindow* pojavWindow;
     basic_render_window_t* mainWindowBundle;
@@ -64,6 +78,8 @@ struct pojav_environ_s {
     bool shouldUpdateMonitorSize, monitorSizeConsumed;
     int savedWidth, savedHeight;
     GLFWgamepadstate gamepadState;
+    Cursor* cursorState;
+    jmethodID method_onCursorStateChange;
 #define ADD_CALLBACK_WWIN(NAME) \
     GLFW_invoke_##NAME##_func* GLFW_invoke_##NAME;
     ADD_CALLBACK_WWIN(Char);

--- a/app_pojavlauncher/src/main/jni/input_bridge_v3.c
+++ b/app_pojavlauncher/src/main/jni/input_bridge_v3.c
@@ -9,7 +9,7 @@
  * 
  * - Implements glfwSetCursorPos() to handle grab camera pos correctly.
  */
- 
+
 #include <assert.h>
 #include <dlfcn.h>
 #include <jni.h>
@@ -55,6 +55,7 @@ jint JNI_OnLoad(JavaVM* vm, __attribute__((unused)) void* reserved) {
         pojav_environ->method_onGrabStateChanged = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "onGrabStateChanged", "(Z)V");
         pojav_environ->method_onDirectInputEnable = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "onDirectInputEnable", "()V");
         pojav_environ->isUseStackQueueCall = JNI_FALSE;
+        pojav_environ->method_onCursorStateChange = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "onCursorStateUpdate", "(Ljava/nio/ByteBuffer;IIII)V");
     } else if (pojav_environ->dalvikJavaVMPtr != vm) {
         LOGI("Saving JVM environ...");
         pojav_environ->runtimeJavaVMPtr = vm;
@@ -82,7 +83,7 @@ jint JNI_OnLoad(JavaVM* vm, __attribute__((unused)) void* reserved) {
         registerFunctions(env);
     }
     pojav_environ->isGrabbing = JNI_FALSE;
-    
+
     return JNI_VERSION_1_4;
 }
 

--- a/jre_lwjgl3glfw/src/main/java/org/lwjgl/glfw/GLFW.java
+++ b/jre_lwjgl3glfw/src/main/java/org/lwjgl/glfw/GLFW.java
@@ -615,7 +615,10 @@ public class GLFW
         SwapInterval = apiGetFunctionAddress(GLFW, "pojavSwapInterval"),
         PumpEvents = apiGetFunctionAddress(GLFW, "pojavPumpEvents"),
         StopPumping = apiGetFunctionAddress(GLFW, "pojavStopPumping"),
-        StartPumping = apiGetFunctionAddress(GLFW, "pojavStartPumping");
+        StartPumping = apiGetFunctionAddress(GLFW, "pojavStartPumping"),
+        CreateCursor = apiGetFunctionAddress(GLFW, "pojavCreateCursor"),
+        DestroyCursor = apiGetFunctionAddress(GLFW, "pojavDestroyCursor"),
+        SetCursor = apiGetFunctionAddress(GLFW, "pojavSetCursor");
     }
 
     public static SharedLibrary getLibrary() {
@@ -1184,14 +1187,33 @@ public class GLFW
         CallbackBridge.sendGrabbing(mGLFWIsGrabbing, (int) xpos, (int) ypos);
     }*/
 
+    public static long nglfwCreateCursor(long image, int xhot, int yhot) {
+        long __functionAddress = Functions.CreateCursor;
+        if (CHECKS) {
+            GLFWImage.validate(image);
+        }
+        return invokePP(image, xhot, yhot, __functionAddress);
+    }
     public static long glfwCreateCursor(@NativeType("const GLFWimage *") GLFWImage image, int xhot, int yhot) {
-        return 4L;
+        return nglfwCreateCursor(image.address(), xhot, yhot);
     }
     public static long glfwCreateStandardCursor(int shape) {
-        return 4L;
+        return 0L;
     }
-    public static void glfwDestroyCursor(@NativeType("GLFWcursor *") long cursor) {}
-    public static void glfwSetCursor(@NativeType("GLFWwindow *") long window, @NativeType("GLFWcursor *") long cursor) {}
+    public static void glfwDestroyCursor(@NativeType("GLFWcursor *") long cursor) {
+        long __functionAddress = Functions.DestroyCursor;
+        if (CHECKS) {
+            check(cursor);
+        }
+        invokePV(cursor, __functionAddress);
+    }
+    public static void glfwSetCursor(@NativeType("GLFWwindow *") long window, @NativeType("GLFWcursor *") long cursor) {
+        long __functionAddress = Functions.SetCursor;
+        if (CHECKS) {
+            check(window);
+        }
+        invokePPV(window, cursor, __functionAddress);
+    }
 
     public static boolean glfwRawMouseMotionSupported() {
         // Should be not supported?


### PR DESCRIPTION
This pull requests implements the following methods:
- `glfwCreateCursor`
- `glfwDestroyCursor`
- `glfwSetCursor`

This enables mods, such as [Minecraft Cursor](https://modrinth.com/mod/minecraft-cursor), to properly change and set the cursor texture. 
A video of this being used: https://youtu.be/msO1tt3KvE4