### PR TITLE
Themed icon variant

### DIFF
--- a/app_pojavlauncher/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app_pojavlauncher/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app_pojavlauncher/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app_pojavlauncher/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
Here's a preview alongside other android apps
 
<img width="556" height="557" alt="Screenshot_20250818-002758~2" src="https://github.com/user-attachments/assets/ff14b1f4-79c7-4304-a735-766346aa7aa1" />


If it doesn't quite feel right I could try to adjust it, it's just using the foreground layer and it looks pretty clean
