### PR TITLE
HACK: feat[jreutils]: override mesa gl/glsl version to 4.6 for zink

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -199,10 +199,10 @@ public class JREUtils {
         // The OPEN GL version is changed according
         envMap.put("LIBGL_ES", (String) ExtraCore.getValue(ExtraConstants.OPEN_GL_VERSION));
 
-	// HACK: GL/GLSL version override for Mesa-based renderers (i.e. Zink)
-	// Required to run the game properly on some mobile Vulkan drivers (Minecraft fails to compile shaders without)
-	envMap.put("MESA_GL_VERSION_OVERRIDE", "4.6");
-	envMap.put("MESA_GLSL_VERSION_OVERRIDE", "460");
+	    // HACK: GL/GLSL version override for Mesa-based renderers (i.e. Zink)
+	    // Required to run the game properly on some mobile Vulkan drivers (Minecraft fails to compile shaders without)
+	    envMap.put("MESA_GL_VERSION_OVERRIDE", "4.6");
+        envMap.put("MESA_GLSL_VERSION_OVERRIDE", "460");
 
         envMap.put("FORCE_VSYNC", String.valueOf(LauncherPreferences.PREF_FORCE_VSYNC));
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -199,6 +199,11 @@ public class JREUtils {
         // The OPEN GL version is changed according
         envMap.put("LIBGL_ES", (String) ExtraCore.getValue(ExtraConstants.OPEN_GL_VERSION));
 
+	// HACK: GL/GLSL version override for Mesa-based renderers (i.e. Zink)
+	// Required to run the game properly on some mobile Vulkan drivers (Minecraft fails to compile shaders without)
+	envMap.put("MESA_GL_VERSION_OVERRIDE", "4.6");
+	envMap.put("MESA_GLSL_VERSION_OVERRIDE", "460");
+
         envMap.put("FORCE_VSYNC", String.valueOf(LauncherPreferences.PREF_FORCE_VSYNC));
 
         envMap.put("MESA_GLSL_CACHE_DIR", Tools.DIR_CACHE.getAbsolutePath());


### PR DESCRIPTION
This hack fixes running Zink on some Vulkan drivers (mostly Mali and Xclipse). Without this change, MC runs but eventually crashes after shader compile failures.  
Zink is generally worse than other renderers, but there are some rare reasons to use it - mostly for shader compatibility.

Unlike my previous PR, this forces GLSL version on every renderer by default, however, only Zink benefits from this by obvious reasons.

~~Not tested~~
