### PR TITLE
Implement glfw cursor functions (again)

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavApplication.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavApplication.java
@@ -2,29 +2,38 @@ package net.kdt.pojavlaunch;
 
 import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
 
-import android.app.*;
-import android.content.*;
-import android.content.pm.*;
-import android.content.res.*;
-import android.os.*;
-import androidx.core.app.*;
+import android.app.Application;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.res.Configuration;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.util.Log;
 
-import android.util.*;
-import java.io.*;
-import java.text.*;
-import java.util.*;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.res.ResourcesCompat;
+
+import net.kdt.pojavlaunch.customcontrols.mouse.CursorContainer;
+import net.kdt.pojavlaunch.lifecycle.ContextExecutor;
+import net.kdt.pojavlaunch.prefs.LauncherPreferences;
+import net.kdt.pojavlaunch.tasks.AsyncAssetManager;
+import net.kdt.pojavlaunch.utils.FileUtils;
+import net.kdt.pojavlaunch.utils.LocaleUtils;
+
+import org.lwjgl.glfw.CallbackBridge;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.text.DateFormat;
+import java.util.Date;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import net.kdt.pojavlaunch.lifecycle.ContextExecutor;
-import net.kdt.pojavlaunch.prefs.LauncherPreferences;
-import net.kdt.pojavlaunch.tasks.AsyncAssetManager;
-import net.kdt.pojavlaunch.utils.*;
-import net.kdt.pojavlaunch.utils.FileUtils;
-
 import git.artdeell.mojo.BuildConfig;
+import git.artdeell.mojo.R;
 
 public class PojavApplication extends Application {
 	public static final String CRASH_REPORT_TAG = "PojavCrashReport";
@@ -84,6 +93,16 @@ public class PojavApplication extends Application {
 			ferrorIntent.setFlags(FLAG_ACTIVITY_NEW_TASK);
 			startActivity(ferrorIntent);
 		}
+
+		Drawable mousePointerDrawable = ResourcesCompat.getDrawable(getResources(), R.drawable.ic_mouse_pointer, getTheme());
+		// For some reason it's annotated as Nullable even though it doesn't seem to actually
+		// ever return null
+		assert mousePointerDrawable != null;
+		mousePointerDrawable.setBounds(0, 0, 36, 54);
+		CallbackBridge.setupDefaultCursor(new CursorContainer(
+				mousePointerDrawable,
+				1, 1
+		));
 	}
 
 	@Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavApplication.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavApplication.java
@@ -7,21 +7,16 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
-import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.util.Log;
 
 import androidx.core.app.ActivityCompat;
-import androidx.core.content.res.ResourcesCompat;
 
-import net.kdt.pojavlaunch.customcontrols.mouse.CursorContainer;
 import net.kdt.pojavlaunch.lifecycle.ContextExecutor;
 import net.kdt.pojavlaunch.prefs.LauncherPreferences;
 import net.kdt.pojavlaunch.tasks.AsyncAssetManager;
 import net.kdt.pojavlaunch.utils.FileUtils;
 import net.kdt.pojavlaunch.utils.LocaleUtils;
-
-import org.lwjgl.glfw.CallbackBridge;
 
 import java.io.File;
 import java.io.PrintStream;
@@ -33,7 +28,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import git.artdeell.mojo.BuildConfig;
-import git.artdeell.mojo.R;
 
 public class PojavApplication extends Application {
 	public static final String CRASH_REPORT_TAG = "PojavCrashReport";
@@ -93,16 +87,6 @@ public class PojavApplication extends Application {
 			ferrorIntent.setFlags(FLAG_ACTIVITY_NEW_TASK);
 			startActivity(ferrorIntent);
 		}
-
-		Drawable mousePointerDrawable = ResourcesCompat.getDrawable(getResources(), R.drawable.ic_mouse_pointer, getTheme());
-		// For some reason it's annotated as Nullable even though it doesn't seem to actually
-		// ever return null
-		assert mousePointerDrawable != null;
-		mousePointerDrawable.setBounds(0, 0, 36, 54);
-		CallbackBridge.setupDefaultCursor(new CursorContainer(
-				mousePointerDrawable,
-				1, 1
-		));
 	}
 
 	@Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/CursorContainer.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/CursorContainer.java
@@ -1,0 +1,39 @@
+package net.kdt.pojavlaunch.customcontrols.mouse;
+
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Contains cursor data and the draw method
+ */
+public class CursorContainer {
+    private final Drawable drawable;
+    private final int xHotspot;
+    private final int yHotspot;
+
+    public CursorContainer(Drawable drawable, int xHotspot, int yHotspot) {
+        this.drawable = drawable;
+        this.xHotspot = xHotspot;
+        this.yHotspot = yHotspot;
+    }
+
+    public void draw(@NonNull Canvas canvas) {
+        canvas.translate(-xHotspot, -yHotspot);
+
+        drawable.draw(canvas);
+    }
+
+    public Drawable getDrawable() {
+        return drawable;
+    }
+
+    public int getXHotspot() {
+        return xHotspot;
+    }
+
+    public int getYHotspot() {
+        return yHotspot;
+    }
+}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/Touchpad.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/Touchpad.java
@@ -2,18 +2,22 @@ package net.kdt.pojavlaunch.customcontrols.mouse;
 
 import android.content.Context;
 import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.res.ResourcesCompat;
 import androidx.core.util.Consumer;
 
 import net.kdt.pojavlaunch.GrabListener;
 import net.kdt.pojavlaunch.prefs.LauncherPreferences;
 
 import org.lwjgl.glfw.CallbackBridge;
+
+import git.artdeell.mojo.R;
 
 /**
  * Class dealing with the virtual mouse
@@ -24,6 +28,7 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
     /* Mouse pointer icon used by the touchpad */
     private float mMouseX, mMouseY;
     private boolean mMoveOnLayout;
+    private Drawable mMouseCursorDrawable;
     private final Consumer<CursorContainer> onCursorChange = cursor->invalidate();
     public Touchpad(@NonNull Context context) {
         this(context, null);
@@ -77,10 +82,19 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
     protected void onDraw(Canvas canvas) {
         canvas.translate(mMouseX, mMouseY);
         canvas.scale(LauncherPreferences.PREF_MOUSESCALE, LauncherPreferences.PREF_MOUSESCALE);
-        CallbackBridge.getCursor().draw(canvas);
+        if(CallbackBridge.getCursor() != null) {
+            CallbackBridge.getCursor().draw(canvas);
+        } else {
+            mMouseCursorDrawable.draw(canvas);
+        }
     }
 
     private void init() {
+        mMouseCursorDrawable = ResourcesCompat.getDrawable(getResources(), R.drawable.ic_mouse_pointer, getContext().getTheme());
+        // For some reason it's annotated as Nullable even though it doesn't seem to actually
+        // ever return null
+        assert mMouseCursorDrawable != null;
+        mMouseCursorDrawable.setBounds(0, 0, 36, 54);
         CallbackBridge.addCursorChangeListener(onCursorChange);
 
         setFocusable(false);

--- a/app_pojavlauncher/src/main/jni/Android.mk
+++ b/app_pojavlauncher/src/main/jni/Android.mk
@@ -35,7 +35,8 @@ LOCAL_SRC_FILES := \
     jre_launcher.c \
     utils.c \
     stdio_is.c \
-    driver_helper/nsbypass.c
+    driver_helper/nsbypass.c \
+    linkedlist.c
 
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
 LOCAL_CFLAGS += -DADRENO_POSSIBLE

--- a/app_pojavlauncher/src/main/jni/egl_bridge.c
+++ b/app_pojavlauncher/src/main/jni/egl_bridge.c
@@ -291,6 +291,7 @@ EXTERNAL_API void* pojavCreateCursor(GLFWimage* image, int xhot, int yhot) {
                                           image->width, image->height, xhot, yhot);
     jobject globalCursor = (*env)->NewGlobalRef(env, cursor);
     // not needed anymore
+    (*env)->DeleteLocalRef(env, cursor);
     (*env)->DeleteLocalRef(env, buffer);
 
     linkedlist_append(pojav_environ->cursors, globalCursor);
@@ -321,6 +322,10 @@ EXTERNAL_API void pojavDestroyCursor(jobject cursor) {
             } else {
                 prev->next = current->next;
             }
+            if (current == pojav_environ->cursors->last) {
+                pojav_environ->cursors->last = prev;
+            }
+
             (*env)->DeleteGlobalRef(env, current->value);
             free(current);
             break;

--- a/app_pojavlauncher/src/main/jni/egl_bridge.c
+++ b/app_pojavlauncher/src/main/jni/egl_bridge.c
@@ -260,7 +260,7 @@ EXTERNAL_API void pojavSwapInterval(int interval) {
     br_swap_interval(interval);
 }
 
-EXTERNAL_API void* pojavCreateStandardCursor(int shape) {
+EXTERNAL_API void* pojavCreateStandardCursor(__attribute__((unused)) int shape) {
     if(pojav_environ->standardCursor != NULL) return pojav_environ->standardCursor;
 
     TRY_ATTACH_ENV(env, pojav_environ->dalvikJavaVMPtr, "failed to attach env from pojavCreateStandardCursor!\n", return NULL;);
@@ -287,19 +287,16 @@ EXTERNAL_API void* pojavCreateCursor(GLFWimage* image, int xhot, int yhot) {
         return NULL;
     }
 
-    jobject cursor = (*env)->CallStaticObjectMethod(env, pojav_environ->bridgeClazz,
+    // creates a global ref so there is no need to create one here
+    jlong cursor = (*env)->CallStaticLongMethod(env, pojav_environ->bridgeClazz,
                                           pojav_environ->method_createCursor, buffer,
                                           image->width, image->height, xhot, yhot);
-    jobject globalCursorRef = (*env)->NewGlobalRef(env, cursor);
-
     // not needed anymore
     (*env)->DeleteLocalRef(env, buffer);
-    (*env)->DeleteLocalRef(env, cursor);
-
-    return globalCursorRef;
+    return (jobject)cursor;
 }
 
-EXTERNAL_API void pojavSetCursor(void* window, jobject cursor) {
+EXTERNAL_API void pojavSetCursor(__attribute__((unused)) void* window, jobject cursor) {
     if(cursor == NULL) {
         void* standardCursor = pojavCreateStandardCursor(0);
         if(standardCursor == NULL) {
@@ -310,7 +307,7 @@ EXTERNAL_API void pojavSetCursor(void* window, jobject cursor) {
     }
 
     TRY_ATTACH_ENV(env, pojav_environ->dalvikJavaVMPtr, "failed to attach env from pojavSetCursor!\n", return;);
-    (*env)->CallStaticVoidMethod(env, pojav_environ->bridgeClazz, pojav_environ->method_setCursor, cursor);
+    (*env)->CallStaticVoidMethod(env, pojav_environ->bridgeClazz, pojav_environ->method_setCursor, (jlong)cursor);
 }
 
 EXTERNAL_API void pojavDestroyCursor(jobject cursor) {
@@ -320,5 +317,5 @@ EXTERNAL_API void pojavDestroyCursor(jobject cursor) {
     }
 
     TRY_ATTACH_ENV(env, pojav_environ->dalvikJavaVMPtr, "failed to attach env from pojavDestroyCursor!\n", return;);
-    (*env)->CallStaticVoidMethod(env, pojav_environ->bridgeClazz, pojav_environ->method_removeCursor, cursor);
+    (*env)->CallStaticVoidMethod(env, pojav_environ->bridgeClazz, pojav_environ->method_removeCursor, (jlong)cursor);
 }

--- a/app_pojavlauncher/src/main/jni/environ/environ.h
+++ b/app_pojavlauncher/src/main/jni/environ/environ.h
@@ -33,6 +33,13 @@ typedef struct  {
     float axes[6];
 } GLFWgamepadstate;
 
+// https://www.glfw.org/docs/3.1/structGLFWimage.html
+typedef struct {
+    int width;
+    int height;
+    unsigned char* pixels;
+} GLFWimage;
+
 struct pojav_environ_s {
     struct ANativeWindow* pojavWindow;
     basic_render_window_t* mainWindowBundle;
@@ -64,6 +71,10 @@ struct pojav_environ_s {
     bool shouldUpdateMonitorSize, monitorSizeConsumed;
     int savedWidth, savedHeight;
     GLFWgamepadstate gamepadState;
+    jmethodID method_getDefaultCursor;
+    jmethodID method_setCursor;
+    jmethodID method_removeCursor;
+    jmethodID method_createCursor;
 #define ADD_CALLBACK_WWIN(NAME) \
     GLFW_invoke_##NAME##_func* GLFW_invoke_##NAME;
     ADD_CALLBACK_WWIN(Char);

--- a/app_pojavlauncher/src/main/jni/environ/environ.h
+++ b/app_pojavlauncher/src/main/jni/environ/environ.h
@@ -75,6 +75,8 @@ struct pojav_environ_s {
     jmethodID method_setCursor;
     jmethodID method_removeCursor;
     jmethodID method_createCursor;
+    jmethodID method_removeAllCursors;
+    jobject standardCursor;
 #define ADD_CALLBACK_WWIN(NAME) \
     GLFW_invoke_##NAME##_func* GLFW_invoke_##NAME;
     ADD_CALLBACK_WWIN(Char);

--- a/app_pojavlauncher/src/main/jni/environ/environ.h
+++ b/app_pojavlauncher/src/main/jni/environ/environ.h
@@ -8,6 +8,7 @@
 #include <ctxbridges/common.h>
 #include <stdatomic.h>
 #include <jni.h>
+#include "linkedlist.h"
 
 /* How many events can be handled at the same time */
 #define EVENT_WINDOW_SIZE 8000
@@ -71,12 +72,10 @@ struct pojav_environ_s {
     bool shouldUpdateMonitorSize, monitorSizeConsumed;
     int savedWidth, savedHeight;
     GLFWgamepadstate gamepadState;
-    jmethodID method_getDefaultCursor;
     jmethodID method_setCursor;
     jmethodID method_removeCursor;
     jmethodID method_createCursor;
-    jmethodID method_removeAllCursors;
-    jobject standardCursor;
+    LinkedList* cursors;
 #define ADD_CALLBACK_WWIN(NAME) \
     GLFW_invoke_##NAME##_func* GLFW_invoke_##NAME;
     ADD_CALLBACK_WWIN(Char);

--- a/app_pojavlauncher/src/main/jni/input_bridge_v3.c
+++ b/app_pojavlauncher/src/main/jni/input_bridge_v3.c
@@ -616,7 +616,12 @@ LinkedListNode* pojavCreateCursor(GLFWimage* image, int xhot, int yhot) {
     (*env)->DeleteLocalRef(env, cursor);
     (*env)->DeleteLocalRef(env, buffer);
 
-    return linkedlist_append(pojav_environ->cursors, globalCursor);
+    LinkedListNode* node = linkedlist_append(pojav_environ->cursors, globalCursor);
+    if(!node) {
+        (*env)->DeleteGlobalRef(env, globalCursor);
+        return NULL;
+    }
+    return node;
 }
 
 void pojavSetCursor(__attribute__((unused)) void* window, LinkedListNode* cursor) {

--- a/app_pojavlauncher/src/main/jni/input_bridge_v3.c
+++ b/app_pojavlauncher/src/main/jni/input_bridge_v3.c
@@ -54,6 +54,10 @@ jint JNI_OnLoad(JavaVM* vm, __attribute__((unused)) void* reserved) {
         pojav_environ->method_accessAndroidClipboard = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "accessAndroidClipboard", "(ILjava/lang/String;)Ljava/lang/String;");
         pojav_environ->method_onGrabStateChanged = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "onGrabStateChanged", "(Z)V");
         pojav_environ->method_onDirectInputEnable = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "onDirectInputEnable", "()V");
+        pojav_environ->method_createCursor = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "createCursor", "(Ljava/nio/ByteBuffer;IIII)Lnet/kdt/pojavlaunch/customcontrols/mouse/CursorContainer;");
+        pojav_environ->method_getDefaultCursor = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "getDefaultCursor", "()Lnet/kdt/pojavlaunch/customcontrols/mouse/CursorContainer;");
+        pojav_environ->method_setCursor = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "setCursor", "(Lnet/kdt/pojavlaunch/customcontrols/mouse/CursorContainer;)V");
+        pojav_environ->method_removeCursor = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "removeCursor", "(Lnet/kdt/pojavlaunch/customcontrols/mouse/CursorContainer;)V");
         pojav_environ->isUseStackQueueCall = JNI_FALSE;
     } else if (pojav_environ->dalvikJavaVMPtr != vm) {
         LOGI("Saving JVM environ...");

--- a/app_pojavlauncher/src/main/jni/input_bridge_v3.c
+++ b/app_pojavlauncher/src/main/jni/input_bridge_v3.c
@@ -58,6 +58,7 @@ jint JNI_OnLoad(JavaVM* vm, __attribute__((unused)) void* reserved) {
         pojav_environ->method_getDefaultCursor = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "getDefaultCursor", "()Lnet/kdt/pojavlaunch/customcontrols/mouse/CursorContainer;");
         pojav_environ->method_setCursor = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "setCursor", "(Lnet/kdt/pojavlaunch/customcontrols/mouse/CursorContainer;)V");
         pojav_environ->method_removeCursor = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "removeCursor", "(Lnet/kdt/pojavlaunch/customcontrols/mouse/CursorContainer;)V");
+        pojav_environ->method_removeAllCursors = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "removeAllCursors", "()V");
         pojav_environ->isUseStackQueueCall = JNI_FALSE;
     } else if (pojav_environ->dalvikJavaVMPtr != vm) {
         LOGI("Saving JVM environ...");
@@ -88,6 +89,18 @@ jint JNI_OnLoad(JavaVM* vm, __attribute__((unused)) void* reserved) {
     pojav_environ->isGrabbing = JNI_FALSE;
     
     return JNI_VERSION_1_4;
+}
+
+void JNI_OnUnload(JavaVM* vm, __attribute__((unused)) void* reserved) {
+    if(pojav_environ->dalvikJavaVMPtr == vm) {
+        JNIEnv *vmEnv;
+        (*vm)->GetEnv(vm, (void**) &vmEnv, JNI_VERSION_1_4);
+
+        if(pojav_environ->standardCursor != NULL) {
+            (*vmEnv)->DeleteGlobalRef(vmEnv, pojav_environ->standardCursor);
+            pojav_environ->standardCursor = NULL;
+        }
+    }
 }
 
 #define ADD_CALLBACK_WWIN(NAME) \
@@ -557,4 +570,10 @@ Java_org_lwjgl_glfw_CallbackBridge_nativeCreateGamepadButtonBuffer(JNIEnv *env, 
 JNIEXPORT jobject JNICALL
 Java_org_lwjgl_glfw_CallbackBridge_nativeCreateGamepadAxisBuffer(JNIEnv *env, jclass clazz) {
     return (*env)->NewDirectByteBuffer(env, &pojav_environ->gamepadState.axes, sizeof(pojav_environ->gamepadState.axes));
+}
+
+JNIEXPORT void JNICALL
+Java_org_lwjgl_glfw_CallbackBridge_nativeDeleteGlobalRef(JNIEnv *env, jclass clazz,
+                                                         jobject object) {
+    (*env)->DeleteGlobalRef(env, object);
 }

--- a/app_pojavlauncher/src/main/jni/input_bridge_v3.c
+++ b/app_pojavlauncher/src/main/jni/input_bridge_v3.c
@@ -54,10 +54,10 @@ jint JNI_OnLoad(JavaVM* vm, __attribute__((unused)) void* reserved) {
         pojav_environ->method_accessAndroidClipboard = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "accessAndroidClipboard", "(ILjava/lang/String;)Ljava/lang/String;");
         pojav_environ->method_onGrabStateChanged = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "onGrabStateChanged", "(Z)V");
         pojav_environ->method_onDirectInputEnable = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "onDirectInputEnable", "()V");
-        pojav_environ->method_createCursor = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "createCursor", "(Ljava/nio/ByteBuffer;IIII)Lnet/kdt/pojavlaunch/customcontrols/mouse/CursorContainer;");
+        pojav_environ->method_createCursor = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "createCursor", "(Ljava/nio/ByteBuffer;IIII)J");
         pojav_environ->method_getDefaultCursor = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "getDefaultCursor", "()Lnet/kdt/pojavlaunch/customcontrols/mouse/CursorContainer;");
         pojav_environ->method_setCursor = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "setCursor", "(Lnet/kdt/pojavlaunch/customcontrols/mouse/CursorContainer;)V");
-        pojav_environ->method_removeCursor = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "removeCursor", "(Lnet/kdt/pojavlaunch/customcontrols/mouse/CursorContainer;)V");
+        pojav_environ->method_removeCursor = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "removeCursor", "(J)V");
         pojav_environ->method_removeAllCursors = (*dvEnv)->GetStaticMethodID(dvEnv, pojav_environ->bridgeClazz, "removeAllCursors", "()V");
         pojav_environ->isUseStackQueueCall = JNI_FALSE;
     } else if (pojav_environ->dalvikJavaVMPtr != vm) {
@@ -574,6 +574,18 @@ Java_org_lwjgl_glfw_CallbackBridge_nativeCreateGamepadAxisBuffer(JNIEnv *env, jc
 
 JNIEXPORT void JNICALL
 Java_org_lwjgl_glfw_CallbackBridge_nativeDeleteGlobalRef(JNIEnv *env, jclass clazz,
-                                                         jobject object) {
-    (*env)->DeleteGlobalRef(env, object);
+                                                         jlong object) {
+    (*env)->DeleteGlobalRef(env, (jobject)object);
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_lwjgl_glfw_CallbackBridge_nativeGetGlobalRef(JNIEnv *env, jclass clazz, jlong pointer) {
+    jobject obj = (jobject) pointer;
+    return obj;
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_lwjgl_glfw_CallbackBridge_nativeCreateGlobalRef(JNIEnv *env, jclass clazz, jobject obj) {
+    jobject globalObj = (*env)->NewGlobalRef(env, obj);
+    return (jlong) globalObj;
 }

--- a/app_pojavlauncher/src/main/jni/linkedlist.c
+++ b/app_pojavlauncher/src/main/jni/linkedlist.c
@@ -14,6 +14,7 @@ LinkedList* linkedlist_init() {
 
 LinkedListNode *linkedlist_append(LinkedList* list, void* value) {
     LinkedListNode* node = malloc(sizeof(LinkedListNode));
+    if(!node) return NULL;
     node->value = value;
     node->next = NULL;
     node->prev = list->last;

--- a/app_pojavlauncher/src/main/jni/linkedlist.c
+++ b/app_pojavlauncher/src/main/jni/linkedlist.c
@@ -1,0 +1,26 @@
+//
+// Created by andre on 21.07.2025.
+//
+
+#include "linkedlist.h"
+#include <stdlib.h>
+
+LinkedList* linkedlist_init() {
+    LinkedList* list = malloc(sizeof(LinkedList));
+    list->first = NULL;
+    list->last = NULL;
+    return list;
+}
+
+void linkedlist_append(LinkedList* list, void* value) {
+    LinkedListNode* node = malloc(sizeof(LinkedListNode));
+    node->value = value;
+    node->next = NULL;
+
+    if (list->last) {
+        list->last->next = node;
+    } else {
+        list->first = node;
+    }
+    list->last = node;
+}

--- a/app_pojavlauncher/src/main/jni/linkedlist.c
+++ b/app_pojavlauncher/src/main/jni/linkedlist.c
@@ -12,10 +12,11 @@ LinkedList* linkedlist_init() {
     return list;
 }
 
-void linkedlist_append(LinkedList* list, void* value) {
+LinkedListNode *linkedlist_append(LinkedList* list, void* value) {
     LinkedListNode* node = malloc(sizeof(LinkedListNode));
     node->value = value;
     node->next = NULL;
+    node->prev = list->last;
 
     if (list->last) {
         list->last->next = node;
@@ -23,4 +24,24 @@ void linkedlist_append(LinkedList* list, void* value) {
         list->first = node;
     }
     list->last = node;
+
+    return node;
+}
+
+void linkedlist_remove(LinkedList* list, LinkedListNode* node) {
+    if (node->prev) {
+        node->prev->next = node->next;
+    } else {
+        list->first = node->next;
+    }
+
+    if (node->next) {
+        node->next->prev = node->prev;
+    } else {
+        list->last = node->prev;
+    }
+
+    node->next = NULL;
+    node->prev = NULL;
+    free(node);
 }

--- a/app_pojavlauncher/src/main/jni/linkedlist.h
+++ b/app_pojavlauncher/src/main/jni/linkedlist.h
@@ -1,0 +1,22 @@
+//
+// Created by andre on 21.07.2025.
+//
+
+#ifndef POJAVLAUNCHER_LINKEDLIST_H
+#define POJAVLAUNCHER_LINKEDLIST_H
+
+typedef struct LinkedListNode {
+    void* value;
+    struct LinkedListNode* next;
+} LinkedListNode;
+
+typedef struct {
+    LinkedListNode* first;
+    LinkedListNode* last;
+} LinkedList;
+
+LinkedList* linkedlist_init();
+void linkedlist_append(LinkedList* list, void* value);
+void linkedlist_free(LinkedList* list);
+
+#endif //POJAVLAUNCHER_LINKEDLIST_H

--- a/app_pojavlauncher/src/main/jni/linkedlist.h
+++ b/app_pojavlauncher/src/main/jni/linkedlist.h
@@ -8,6 +8,7 @@
 typedef struct LinkedListNode {
     void* value;
     struct LinkedListNode* next;
+    struct LinkedListNode* prev;
 } LinkedListNode;
 
 typedef struct {
@@ -16,7 +17,7 @@ typedef struct {
 } LinkedList;
 
 LinkedList* linkedlist_init();
-void linkedlist_append(LinkedList* list, void* value);
-void linkedlist_free(LinkedList* list);
+LinkedListNode *linkedlist_append(LinkedList* list, void* value);
+void linkedlist_remove(LinkedList* list, LinkedListNode* node);
 
 #endif //POJAVLAUNCHER_LINKEDLIST_H

--- a/jre_lwjgl3glfw/src/main/java/org/lwjgl/glfw/GLFW.java
+++ b/jre_lwjgl3glfw/src/main/java/org/lwjgl/glfw/GLFW.java
@@ -4,24 +4,43 @@
  */
 package org.lwjgl.glfw;
 
-import android.util.*;
+import static org.lwjgl.opengl.GL20.GL_EXTENSIONS;
+import static org.lwjgl.opengl.GL20.glGetString;
+import static org.lwjgl.system.APIUtil.apiGetFunctionAddress;
+import static org.lwjgl.system.Checks.CHECKS;
+import static org.lwjgl.system.Checks.check;
+import static org.lwjgl.system.Checks.checkSafe;
+import static org.lwjgl.system.JNI.callJV;
+import static org.lwjgl.system.JNI.callV;
+import static org.lwjgl.system.JNI.invokeI;
+import static org.lwjgl.system.JNI.invokeP;
+import static org.lwjgl.system.JNI.invokePP;
+import static org.lwjgl.system.JNI.invokePPV;
+import static org.lwjgl.system.JNI.invokePV;
+import static org.lwjgl.system.JNI.invokeV;
+import static org.lwjgl.system.MemoryStack.stackGet;
+import static org.lwjgl.system.MemoryUtil.memAddressSafe;
+import static org.lwjgl.system.MemoryUtil.memPutInt;
+import static org.lwjgl.system.MemoryUtil.memUTF8Safe;
 
-import java.lang.reflect.*;
-import java.nio.*;
+import android.util.ArrayMap;
 
-import javax.annotation.*;
-
-import org.lwjgl.*;
-import org.lwjgl.system.*;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.Library;
+import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
+import org.lwjgl.system.NativeType;
+import org.lwjgl.system.SharedLibrary;
 
-import static org.lwjgl.opengl.GL20.*;
-import static org.lwjgl.system.APIUtil.*;
-import static org.lwjgl.system.Checks.*;
-import static org.lwjgl.system.JNI.*;
-import static org.lwjgl.system.MemoryStack.*;
-import static org.lwjgl.system.MemoryUtil.*;
-import java.util.*;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.util.Map;
+
+import javax.annotation.Nullable;
 
 public class GLFW
 {
@@ -599,7 +618,6 @@ public class GLFW
 
     /** Contains the function pointers loaded from the glfw {@link SharedLibrary}. */
     public static final class Functions {
-
         private Functions() {}
 
         /** Function address. */
@@ -615,7 +633,11 @@ public class GLFW
         SwapInterval = apiGetFunctionAddress(GLFW, "pojavSwapInterval"),
         PumpEvents = apiGetFunctionAddress(GLFW, "pojavPumpEvents"),
         StopPumping = apiGetFunctionAddress(GLFW, "pojavStopPumping"),
-        StartPumping = apiGetFunctionAddress(GLFW, "pojavStartPumping");
+        StartPumping = apiGetFunctionAddress(GLFW, "pojavStartPumping"),
+        CreateCursor = apiGetFunctionAddress(GLFW, "pojavCreateCursor"),
+        SetCursor = apiGetFunctionAddress(GLFW, "pojavSetCursor"),
+        CreateStandardCursor = apiGetFunctionAddress(GLFW, "pojavCreateStandardCursor"),
+        DestroyCursor = apiGetFunctionAddress(GLFW, "pojavDestroyCursor");
     }
 
     public static SharedLibrary getLibrary() {
@@ -1184,14 +1206,37 @@ public class GLFW
         CallbackBridge.sendGrabbing(mGLFWIsGrabbing, (int) xpos, (int) ypos);
     }*/
 
-    public static long glfwCreateCursor(@NativeType("const GLFWimage *") GLFWImage image, int xhot, int yhot) {
-        return 4L;
+    public static long nglfwCreateCursor(long image, int xhot, int yhot) {
+        long __functionAddress = Functions.CreateCursor;
+        if (CHECKS) {
+            GLFWImage.validate(image);
+        }
+        return invokePP(image, xhot, yhot, __functionAddress);
     }
+
+    @NativeType("GLFWcursor *")
+    public static long glfwCreateCursor(@NativeType("GLFWimage const *") GLFWImage image, int xhot, int yhot) {
+        return nglfwCreateCursor(image.address(), xhot, yhot);
+    }
+    @NativeType("GLFWcursor *")
     public static long glfwCreateStandardCursor(int shape) {
-        return 4L;
+        long __functionAddress = Functions.CreateStandardCursor;
+        return invokeP(shape, __functionAddress);
     }
-    public static void glfwDestroyCursor(@NativeType("GLFWcursor *") long cursor) {}
-    public static void glfwSetCursor(@NativeType("GLFWwindow *") long window, @NativeType("GLFWcursor *") long cursor) {}
+    public static void glfwDestroyCursor(@NativeType("GLFWcursor *") long cursor) {
+        long __functionAddress = Functions.DestroyCursor;
+        if (CHECKS) {
+            check(cursor);
+        }
+        invokePV(cursor, __functionAddress);
+    }
+    public static void glfwSetCursor(@NativeType("GLFWwindow *") long window, @NativeType("GLFWcursor *") long cursor) {
+        long __functionAddress = Functions.SetCursor;
+        if (CHECKS) {
+            check(window);
+        }
+        invokePPV(window, cursor, __functionAddress);
+    }
 
     public static boolean glfwRawMouseMotionSupported() {
         // Should be not supported?

--- a/jre_lwjgl3glfw/src/main/java/org/lwjgl/glfw/GLFW.java
+++ b/jre_lwjgl3glfw/src/main/java/org/lwjgl/glfw/GLFW.java
@@ -636,7 +636,6 @@ public class GLFW
         StartPumping = apiGetFunctionAddress(GLFW, "pojavStartPumping"),
         CreateCursor = apiGetFunctionAddress(GLFW, "pojavCreateCursor"),
         SetCursor = apiGetFunctionAddress(GLFW, "pojavSetCursor"),
-        CreateStandardCursor = apiGetFunctionAddress(GLFW, "pojavCreateStandardCursor"),
         DestroyCursor = apiGetFunctionAddress(GLFW, "pojavDestroyCursor");
     }
 
@@ -1220,8 +1219,7 @@ public class GLFW
     }
     @NativeType("GLFWcursor *")
     public static long glfwCreateStandardCursor(int shape) {
-        long __functionAddress = Functions.CreateStandardCursor;
-        return invokeP(shape, __functionAddress);
+        return 0L; // default cursor is rendered when cursor == null
     }
     public static void glfwDestroyCursor(@NativeType("GLFWcursor *") long cursor) {
         long __functionAddress = Functions.DestroyCursor;


### PR DESCRIPTION
This is an improved implementation of #66

Originally, #66 was quite flawed for multiple reasons, such as:
- Constant recreation of cursor objects
- Storage of data on native which is only accessed on the dalvik side
- Premultiplication of the image on native 
- Not storing the cursor instances which is required for `glfwTerminate`/`pojavTerminate` to properly destroy all cursor objects

This PR gets rid of those flaws and generally implements the cursor functions (`glfwCreateCursor`, `glfwDestroyCursor`, `glfwSetCursor`) much cleaner than before

This enables mods, such as [Minecraft Cursor](https://modrinth.com/mod/minecraft-cursor), to properly change and set the cursor texture.
You can see the previously mentioned mod being tested here: https://youtu.be/bEDjHFOr2Og