### PR TITLE
Feat: show "Minecraft is paid" notification when creating a local account

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -1461,4 +1461,11 @@ public final class Tools {
                     }
                 }).show();
     }
+    // License nag notification (tells first launch user to buy the game in the future)
+    public static void maybeShowLicenseNag(Context context){
+        if(!LauncherPreferences.PREF_LICENSE_NAGGED){
+            Tools.dialog(context, context.getString(R.string.local_login_buy_game_title), context.getString(R.string.local_login_buy_game));
+            LauncherPreferences.DEFAULT_PREF.edit().putBoolean("licenseNagged", true).apply();
+        }
+    }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -1463,7 +1463,7 @@ public final class Tools {
     }
     // License nag notification (tells first launch user to buy the game in the future)
     public static void maybeShowLicenseNag(Context context){
-        if(!LauncherPreferences.PREF_LICENSE_NAGGED){
+        if(!LauncherPreferences.DEFAULT_PREF.getBoolean("licenseNagged", false)){
             Tools.dialog(context, context.getString(R.string.local_login_buy_game_title), context.getString(R.string.local_login_buy_game));
             LauncherPreferences.DEFAULT_PREF.edit().putBoolean("licenseNagged", true).apply();
         }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LocalLoginFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LocalLoginFragment.java
@@ -11,8 +11,11 @@ import androidx.fragment.app.Fragment;
 
 import git.artdeell.mojo.R;
 import net.kdt.pojavlaunch.Tools;
+import net.kdt.pojavlaunch.authenticator.accounts.MinecraftAccount;
+import net.kdt.pojavlaunch.authenticator.accounts.PojavProfile;
 import net.kdt.pojavlaunch.extra.ExtraConstants;
 import net.kdt.pojavlaunch.extra.ExtraCore;
+import net.kdt.pojavlaunch.prefs.LauncherPreferences;
 
 import java.io.File;
 import java.util.regex.Matcher;
@@ -33,15 +36,21 @@ public class LocalLoginFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         mUsernameEditText = view.findViewById(R.id.login_edit_email);
         view.findViewById(R.id.login_button).setOnClickListener(v -> {
+            Context context = v.getContext();
             if(!checkEditText()) {
-                Context context = v.getContext();
                 Tools.dialog(context, context.getString(R.string.local_login_bad_username_title), context.getString(R.string.local_login_bad_username_text));
                 return;
             }
-
+            // License nag notification (tells first launch user to buy the game in the future)
+            if(!LauncherPreferences.PREF_LICENSE_NAGGED){
+                MinecraftAccount profile;
+                if((profile = PojavProfile.getCurrentProfileContent(true)) == null || !profile.isMicrosoft){
+                    Tools.dialog(context, context.getString(R.string.local_login_buy_game_title), context.getString(R.string.local_login_buy_game));
+                    LauncherPreferences.PREF_LICENSE_NAGGED = true;
+                }
+            }
             ExtraCore.setValue(ExtraConstants.MOJANG_LOGIN_TODO, new String[]{
                     mUsernameEditText.getText().toString(), "" });
-
             Tools.swapFragment(requireActivity(), MainMenuFragment.class, MainMenuFragment.TAG, null);
         });
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LocalLoginFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LocalLoginFragment.java
@@ -41,14 +41,8 @@ public class LocalLoginFragment extends Fragment {
                 Tools.dialog(context, context.getString(R.string.local_login_bad_username_title), context.getString(R.string.local_login_bad_username_text));
                 return;
             }
-            // License nag notification (tells first launch user to buy the game in the future)
-            if(!LauncherPreferences.PREF_LICENSE_NAGGED){
-                MinecraftAccount profile;
-                if((profile = PojavProfile.getCurrentProfileContent(true)) == null || !profile.isMicrosoft){
-                    Tools.dialog(context, context.getString(R.string.local_login_buy_game_title), context.getString(R.string.local_login_buy_game));
-                    LauncherPreferences.DEFAULT_PREF.edit().putBoolean("licenseNagged", true).apply();
-                }
-            }
+            if(PojavProfile.getCurrentProfileContent(true) == null)
+                Tools.maybeShowLicenseNag(context);
             ExtraCore.setValue(ExtraConstants.MOJANG_LOGIN_TODO, new String[]{
                     mUsernameEditText.getText().toString(), "" });
             Tools.swapFragment(requireActivity(), MainMenuFragment.class, MainMenuFragment.TAG, null);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LocalLoginFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LocalLoginFragment.java
@@ -1,7 +1,6 @@
 package net.kdt.pojavlaunch.fragments;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.EditText;
@@ -9,7 +8,6 @@ import android.widget.EditText;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.preference.Preference;
 
 import git.artdeell.mojo.R;
 import net.kdt.pojavlaunch.Tools;
@@ -44,10 +42,12 @@ public class LocalLoginFragment extends Fragment {
                 return;
             }
             // License nag notification (tells first launch user to buy the game in the future)
-            // TODO: show the message only once
-            MinecraftAccount profile;
-            if((profile = PojavProfile.getCurrentProfileContent(true)) == null || !profile.isMicrosoft){
-                Tools.dialog(context, context.getString(R.string.local_login_buy_game_title), context.getString(R.string.local_login_buy_game));
+            if(!LauncherPreferences.PREF_LICENSE_NAGGED){
+                MinecraftAccount profile;
+                if((profile = PojavProfile.getCurrentProfileContent(true)) == null || !profile.isMicrosoft){
+                    Tools.dialog(context, context.getString(R.string.local_login_buy_game_title), context.getString(R.string.local_login_buy_game));
+                    LauncherPreferences.DEFAULT_PREF.edit().putBoolean("licenseNagged", true).apply();
+                }
             }
             ExtraCore.setValue(ExtraConstants.MOJANG_LOGIN_TODO, new String[]{
                     mUsernameEditText.getText().toString(), "" });

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LocalLoginFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LocalLoginFragment.java
@@ -1,6 +1,7 @@
 package net.kdt.pojavlaunch.fragments;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.EditText;
@@ -8,6 +9,7 @@ import android.widget.EditText;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.preference.Preference;
 
 import git.artdeell.mojo.R;
 import net.kdt.pojavlaunch.Tools;
@@ -42,12 +44,10 @@ public class LocalLoginFragment extends Fragment {
                 return;
             }
             // License nag notification (tells first launch user to buy the game in the future)
-            if(!LauncherPreferences.PREF_LICENSE_NAGGED){
-                MinecraftAccount profile;
-                if((profile = PojavProfile.getCurrentProfileContent(true)) == null || !profile.isMicrosoft){
-                    Tools.dialog(context, context.getString(R.string.local_login_buy_game_title), context.getString(R.string.local_login_buy_game));
-                    LauncherPreferences.PREF_LICENSE_NAGGED = true;
-                }
+            // TODO: show the message only once
+            MinecraftAccount profile;
+            if((profile = PojavProfile.getCurrentProfileContent(true)) == null || !profile.isMicrosoft){
+                Tools.dialog(context, context.getString(R.string.local_login_buy_game_title), context.getString(R.string.local_login_buy_game));
             }
             ExtraCore.setValue(ExtraConstants.MOJANG_LOGIN_TODO, new String[]{
                     mUsernameEditText.getText().toString(), "" });

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -35,7 +35,6 @@ public class LauncherPreferences {
 	public static int PREF_LONGPRESS_TRIGGER = 300;
 	public static String PREF_DEFAULTCTRL_PATH = Tools.CTRLDEF_FILE;
 	public static String PREF_CUSTOM_JAVA_ARGS;
-    public static boolean PREF_LICENSE_NAGGED = false;
     public static boolean PREF_FORCE_ENGLISH = false;
     public static final String PREF_VERSION_REPOS = "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json";
     public static boolean PREF_CHECK_LIBRARY_SHA = true;
@@ -90,7 +89,6 @@ public class LauncherPreferences {
         PREF_DISABLE_SWAP_HAND = DEFAULT_PREF.getBoolean("disableDoubleTap", false);
         PREF_RAM_ALLOCATION = DEFAULT_PREF.getInt("allocation", findBestRAMAllocation(ctx));
         PREF_CUSTOM_JAVA_ARGS = DEFAULT_PREF.getString("javaArgs", "");
-        PREF_LICENSE_NAGGED = DEFAULT_PREF.getBoolean("licenseNagged", false);
         PREF_SUSTAINED_PERFORMANCE = DEFAULT_PREF.getBoolean("sustainedPerformance", isDevicePowerful);
         PREF_VIRTUAL_MOUSE_START = DEFAULT_PREF.getBoolean("mouse_start", false);
         PREF_ARC_CAPES = DEFAULT_PREF.getBoolean("arc_capes",false);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -35,6 +35,7 @@ public class LauncherPreferences {
 	public static int PREF_LONGPRESS_TRIGGER = 300;
 	public static String PREF_DEFAULTCTRL_PATH = Tools.CTRLDEF_FILE;
 	public static String PREF_CUSTOM_JAVA_ARGS;
+    public static boolean PREF_LICENSE_NAGGED = false;
     public static boolean PREF_FORCE_ENGLISH = false;
     public static final String PREF_VERSION_REPOS = "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json";
     public static boolean PREF_CHECK_LIBRARY_SHA = true;
@@ -89,6 +90,7 @@ public class LauncherPreferences {
         PREF_DISABLE_SWAP_HAND = DEFAULT_PREF.getBoolean("disableDoubleTap", false);
         PREF_RAM_ALLOCATION = DEFAULT_PREF.getInt("allocation", findBestRAMAllocation(ctx));
         PREF_CUSTOM_JAVA_ARGS = DEFAULT_PREF.getString("javaArgs", "");
+        PREF_LICENSE_NAGGED = DEFAULT_PREF.getBoolean("licenseNagged", false);
         PREF_SUSTAINED_PERFORMANCE = DEFAULT_PREF.getBoolean("sustainedPerformance", isDevicePowerful);
         PREF_VIRTUAL_MOUSE_START = DEFAULT_PREF.getBoolean("mouse_start", false);
         PREF_ARC_CAPES = DEFAULT_PREF.getBoolean("arc_capes",false);

--- a/app_pojavlauncher/src/main/res/values-ar/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ar/strings.xml
@@ -372,4 +372,6 @@
     <string name="local_login_bad_username_title">اسم المستخدم غير مناسب</string>
     <string name="local_login_bad_username_text">يجب أن يكون اسم المستخدم بين 3–16 حرفاً، ويجب أن يحتوي فقط على أحرف لاتينية وأرقام 0-9 وتسطيرات سفلية.</string>
     <string name="quick_setting_title">قائمة الإعدادات السريعة</string>
+    <string name="local_login_buy_game_title>ااشتري ماينكرافت!</string>
+    <string name="local_login_buy_game>يمكنك اللعب بحساب محلي مجانا، لكن ماينكرافت لعبة مدفوعة. نحن نؤمن ان الكل يجب ان يحصل على فرصة لتجربة اللعبة، نأمل ان تشتري اللعبة</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/values-ar/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ar/strings.xml
@@ -372,6 +372,6 @@
     <string name="local_login_bad_username_title">اسم المستخدم غير مناسب</string>
     <string name="local_login_bad_username_text">يجب أن يكون اسم المستخدم بين 3–16 حرفاً، ويجب أن يحتوي فقط على أحرف لاتينية وأرقام 0-9 وتسطيرات سفلية.</string>
     <string name="quick_setting_title">قائمة الإعدادات السريعة</string>
-    <string name="local_login_buy_game_title>ااشتري ماينكرافت!</string>
-    <string name="local_login_buy_game>يمكنك اللعب بحساب محلي مجانا، لكن ماينكرافت لعبة مدفوعة. نحن نؤمن ان الكل يجب ان يحصل على فرصة لتجربة اللعبة، نأمل ان تشتري اللعبة</string>
+    <string name="local_login_buy_game_title">ااشتري ماينكرافت!"</string>
+    <string name="local_login_buy_game">يمكنك اللعب بحساب محلي مجانا، لكن ماينكرافت لعبة مدفوعة. نحن نؤمن ان الكل يجب ان يحصل على فرصة لتجربة اللعبة، نأمل ان تشتري اللعبة</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/values-az-rAZ/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-az-rAZ/strings.xml
@@ -319,6 +319,8 @@
     <string name="exception_failed_to_unpack_jre17">JRE 17 quraşdırmaq alınmadı</string>
     <string name="newdl_starting">Oyun metadatası oxunur…</string>
     <string name="newdl_downloading_metadata">Oyun metadatası endirilir (%s)</string>
+    <string name="local_login_buy_game_title">Minecraft-ı Alın</string>
+    <string name="local_login_buy_game">Lokal hesab pulsuz olsa da, Minecraft pullu bir oyundur. İnanırıq ki, hər kəsin bunu sınamaq şansı vardır və ümid edirik ki, bir gün bu oyunu alacaqsınız</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -383,7 +383,7 @@
     <string name="mcl_button_open_directory">Открыть папку игры</string>
     <string name="local_login_bad_username_title">Неподходящее имя пользователя</string>
     <string name="local_login_bad_username_text">Имя пользователя должно быть от 3 до 16 символов в длину и содержать только латинские символы, цифры 0–9 или нижние подчёркивания.</string>
-    <string name="local_login_buy_game_title">Купите игру</string>
+    <string name="local_login_buy_game_title">Купите Minecraft</string>
     <string name="local_login_buy_game">Хоть локальный аккаунт и бесплатен, Minecraft все ещё является платной игрой. Мы считаем, что каждый должен иметь возможность играть бесплатно, однако предполагаем, что когда-нибудь вы купите Minecraft</string>
     <string name="quick_setting_title">Быстрые настройки</string>
     <string name="create_bta_instance">Создать установку \"Better than Adventure!\"</string>

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -384,7 +384,7 @@
     <string name="local_login_bad_username_title">Неподходящее имя пользователя</string>
     <string name="local_login_bad_username_text">Имя пользователя должно быть от 3 до 16 символов в длину и содержать только латинские символы, цифры 0–9 или нижние подчёркивания.</string>
     <string name="local_login_buy_game_title">Купите Minecraft</string>
-    <string name="local_login_buy_game">Хоть локальный аккаунт и позволяет её запускать бесплатно, Minecraft все ещё является платной игрой. Мы считаем, что каждый должен иметь возможность играть так как ему удобно, однако надеемся, что когда-нибудь вы купите Minecraft</string>
+    <string name="local_login_buy_game">Хоть локальный аккаунт и позволяет запускать игру бесплатно, Minecraft всё ещё является платным. Мы считаем, что каждый должен иметь возможность играть так как ему удобно, однако надеемся, что когда-нибудь вы купите Minecraft</string>
     <string name="quick_setting_title">Быстрые настройки</string>
     <string name="create_bta_instance">Создать установку \"Better than Adventure!\"</string>
     <string name="select_bta_version">Выбрать версию \"Better than Adventure!\"</string>

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -383,6 +383,8 @@
     <string name="mcl_button_open_directory">Открыть папку игры</string>
     <string name="local_login_bad_username_title">Неподходящее имя пользователя</string>
     <string name="local_login_bad_username_text">Имя пользователя должно быть от 3 до 16 символов в длину и содержать только латинские символы, цифры 0–9 или нижние подчёркивания.</string>
+    <string name="local_login_buy_game_title">Купите игру</string>
+    <string name="local_login_buy_game">Хоть локальный аккаунт и бесплатен, Minecraft все ещё является платной игрой. Мы считаем, что каждый должен иметь возможность играть бесплатно, однако предполагаем, что когда-нибудь вы купите Minecraft</string>
     <string name="quick_setting_title">Быстрые настройки</string>
     <string name="create_bta_instance">Создать установку \"Better than Adventure!\"</string>
     <string name="select_bta_version">Выбрать версию \"Better than Adventure!\"</string>

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -384,7 +384,7 @@
     <string name="local_login_bad_username_title">Неподходящее имя пользователя</string>
     <string name="local_login_bad_username_text">Имя пользователя должно быть от 3 до 16 символов в длину и содержать только латинские символы, цифры 0–9 или нижние подчёркивания.</string>
     <string name="local_login_buy_game_title">Купите Minecraft</string>
-    <string name="local_login_buy_game">Хоть локальный аккаунт и бесплатен, Minecraft все ещё является платной игрой. Мы считаем, что каждый должен иметь возможность играть бесплатно, однако предполагаем, что когда-нибудь вы купите Minecraft</string>
+    <string name="local_login_buy_game">Хоть локальный аккаунт и позволяет её запускать бесплатно, Minecraft все ещё является платной игрой. Мы считаем, что каждый должен иметь возможность играть так как ему удобно, однако надеемся, что когда-нибудь вы купите Minecraft</string>
     <string name="quick_setting_title">Быстрые настройки</string>
     <string name="create_bta_instance">Создать установку \"Better than Adventure!\"</string>
     <string name="select_bta_version">Выбрать версию \"Better than Adventure!\"</string>

--- a/app_pojavlauncher/src/main/res/values-uk/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-uk/strings.xml
@@ -327,4 +327,7 @@
     <string name="controller_button_start">Почати</string>
     <string name="controller_button_select">Обрати</string>
     <string name="customctrl_visibility_title">Видимість</string>
+    <string name="local_login_buy_game_title">Купіть Minecraft</string>
+    <string name="local_login_buy_game">Хоча локальний акаунт і дозволяє гру запускати безкоштовно, Minecraft все ще лишається платним, однак сподіваємося, що коли-небудь ви купите Minecraft</string>
+    <string name="quick_setting_title">Швидкі налаштування</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -432,7 +432,7 @@
     <string name="discord_invite" translatable="false">https://discord.gg/VHdwQFsaGX</string>
     <string name="local_login_bad_username_title">Unsuitable username</string>
     <string name="local_login_bad_username_text">The username must be between 3–16 characters long, and must only contain latin letters, numbers 0–9 and underscores.</string>
-    <string name="local_login_buy_game_title">Buy the game</string>
+    <string name="local_login_buy_game_title">Buy Minecraft</string>
     <string name="local_login_buy_game">While local account is free, Minecraft is a paid game. We believe everyone should have a chance to try it, and hope that one day you will purchase it.</string>
     <string name="quick_setting_title">Quick settings</string>
     <string name="create_bta_instance">Create \"Better than Adventure!\" instance</string>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -432,6 +432,8 @@
     <string name="discord_invite" translatable="false">https://discord.gg/VHdwQFsaGX</string>
     <string name="local_login_bad_username_title">Unsuitable username</string>
     <string name="local_login_bad_username_text">The username must be between 3–16 characters long, and must only contain latin letters, numbers 0–9 and underscores.</string>
+    <string name="local_login_buy_game_title">Buy the game</string>
+    <string name="local_login_buy_game">While local account is free, Minecraft is a paid game. We believe everyone should have a chance to try it, and hope that one day you will purchase it.</string>
     <string name="quick_setting_title">Quick settings</string>
     <string name="create_bta_instance">Create \"Better than Adventure!\" instance</string>
     <string name="select_bta_version">Select \"Better than Adventure!\" version</string>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -433,7 +433,7 @@
     <string name="local_login_bad_username_title">Unsuitable username</string>
     <string name="local_login_bad_username_text">The username must be between 3–16 characters long, and must only contain latin letters, numbers 0–9 and underscores.</string>
     <string name="local_login_buy_game_title">Buy Minecraft</string>
-    <string name="local_login_buy_game">While local account is free, Minecraft is a paid game. We believe everyone should have a chance to try it, and hope that one day you will purchase it.</string>
+    <string name="local_login_buy_game">While local account is free, Minecraft is a paid game. We believe everyone should have a chance to try it, and hope that one day you will purchase it</string>
     <string name="quick_setting_title">Quick settings</string>
     <string name="create_bta_instance">Create \"Better than Adventure!\" instance</string>
     <string name="select_bta_version">Select \"Better than Adventure!\" version</string>


### PR DESCRIPTION
This adds a simple dialog/notification message when the user creates a local account. This tells user that the game is not free and while MojoLauncher allows playing it "free", the user should still buy it.

The message is shown if:
* No accounts exist (i.e. manually removed or on the first launch)
* No Microsoft accounts are present

~~For now the message is displayed always, but there's probably an option to make it shown only one time~~
Fixed.

From https://github.com/whitebelyash/MojoLauncher/commit/6108aead76f2a4d573fed43d3b974d6f6d8d0dc9
```
No, this doesn't mean MojoLauncher will remove offline accounts. This is a simple notification
 to tell people that Minecraft is still paid despite the launcher allowing to play it "for free"
```

<img width="465" height="328" alt="изображение" src="https://github.com/user-attachments/assets/926722f1-0412-4681-9691-d82606d3233b" />
