### PR TITLE
fix[modloaders, ForgelikeUtils]: update neoforge metadata link

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/ForgelikeUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/ForgelikeUtils.java
@@ -157,7 +157,7 @@ public abstract class ForgelikeUtils {
         public NeoforgeUtils() {
             super(
                     "NeoForge", "neoforge", "neoforge", "%2$s",
-                    "https://maven.neoforged.net/net/neoforged/neoforge/maven-metadata.xml",
+                    "https://maven.neoforged.net/releases/net/neoforged/neoforge/maven-metadata.xml",
                     "https://maven.neoforged.net/releases/net/neoforged/neoforge/%1$s/neoforge-%1$s-installer.jar",
                     true
             );


### PR DESCRIPTION
This pull request updates the neoforge metadata link, because they have apparently changed the endpoint, which breaks neoforge installation on mojo.