### PR TITLE
Feat[mod_installer/fabric]: fix instance name and add Legacy Fabric installer

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/FabriclikeInstallFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/FabriclikeInstallFragment.java
@@ -115,7 +115,7 @@ public abstract class FabriclikeInstallFragment extends Fragment implements Modl
                 return;
             }
             Instances.createInstance((i)->{
-                i.name = "Fabric";
+                i.name = mFabriclikeUtils.getName();
                 i.icon = mFabriclikeUtils.getIconName();
                 i.versionId = versionId;
             }, versionId);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LegacyFabricInstallFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LegacyFabricInstallFragment.java
@@ -1,11 +1,11 @@
 package net.kdt.pojavlaunch.fragments;
 
 import net.kdt.pojavlaunch.modloaders.FabriclikeUtils;
-import net.kdt.pojavlaunch.modloaders.ModloaderListenerProxy;
 
 public class LegacyFabricInstallFragment extends FabriclikeInstallFragment {
 
     public static final String TAG = "LegacyFabricInstallFragment";
-    private static ModloaderListenerProxy sTaskProxy;
-    public LegacyFabricInstallFragment() {super(FabriclikeUtils.LEGACY_FABRIC_UTILS, TAG);}
+    public LegacyFabricInstallFragment() {
+        super(FabriclikeUtils.LEGACY_FABRIC_UTILS, TAG);
+    }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LegacyFabricInstallFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LegacyFabricInstallFragment.java
@@ -1,0 +1,11 @@
+package net.kdt.pojavlaunch.fragments;
+
+import net.kdt.pojavlaunch.modloaders.FabriclikeUtils;
+import net.kdt.pojavlaunch.modloaders.ModloaderListenerProxy;
+
+public class LegacyFabricInstallFragment extends FabriclikeInstallFragment {
+
+    public static final String TAG = "LegacyFabricInstallFragment";
+    private static ModloaderListenerProxy sTaskProxy;
+    public LegacyFabricInstallFragment() {super(FabriclikeUtils.LEGACY_FABRIC_UTILS, TAG);}
+}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ProfileTypeSelectFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ProfileTypeSelectFragment.java
@@ -51,5 +51,7 @@ public class ProfileTypeSelectFragment extends Fragment {
                 Tools.swapFragment(requireActivity(), BTAInstallFragment.class, BTAInstallFragment.TAG, null));
         view.findViewById(R.id.modded_profile_neoforge).setOnClickListener((v)->
                 Tools.swapFragment(requireActivity(), NeoforgeInstallFragment.class, NeoforgeInstallFragment.TAG, null));
+        view.findViewById(R.id.modded_profile_legacy_fabric).setOnClickListener((v) ->
+                Tools.swapFragment(requireActivity(), LegacyFabricInstallFragment.class, LegacyFabricInstallFragment.TAG, null));
     }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/FabriclikeUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/FabriclikeUtils.java
@@ -19,7 +19,7 @@ public class FabriclikeUtils {
 
     public static final FabriclikeUtils FABRIC_UTILS = new FabriclikeUtils("https://meta.fabricmc.net/v2", "fabric", "Fabric", "fabric");
     public static final FabriclikeUtils QUILT_UTILS = new FabriclikeUtils("https://meta.quiltmc.org/v3", "quilt", "Quilt", "quilt");
-
+    public static final FabriclikeUtils LEGACY_FABRIC_UTILS = new FabriclikeUtils("https://meta.legacyfabric.net/v2", "legacy_fabric", "Legacy Fabric", "fabric");
     private static final String LOADER_METADATA_URL = "%s/versions/loader/%s";
     private static final String GAME_METADATA_URL = "%s/versions/game";
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/ModLoader.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/ModLoader.java
@@ -11,6 +11,7 @@ public class ModLoader {
     public static final int MOD_LOADER_FABRIC = 1;
     public static final int MOD_LOADER_QUILT = 2;
     public static final int MOD_LOADER_NEOFORGE = 3;
+    public static final int MOD_LOADER_LEGACY_FABRIC = 4;
     public final int modLoaderType;
     public final String modLoaderVersion;
     public final String minecraftVersion;
@@ -34,7 +35,9 @@ public class ModLoader {
             case MOD_LOADER_QUILT:
                 return "quilt-loader-"+modLoaderVersion+"-"+minecraftVersion;
             case MOD_LOADER_NEOFORGE:
-                return "neoforge-" + modLoaderVersion;
+                return "neoforge-"+modLoaderVersion;
+            case MOD_LOADER_LEGACY_FABRIC:
+                return "legacy-fabric-loader-"+modLoaderVersion+"-"+minecraftVersion;
             default:
                 return null;
         }
@@ -50,6 +53,8 @@ public class ModLoader {
                 return FabriclikeUtils.FABRIC_UTILS.install(minecraftVersion, modLoaderVersion);
             case MOD_LOADER_QUILT:
                 return FabriclikeUtils.QUILT_UTILS.install(minecraftVersion, modLoaderVersion);
+            case MOD_LOADER_LEGACY_FABRIC:
+                return FabriclikeUtils.LEGACY_FABRIC_UTILS.install(minecraftVersion, modLoaderVersion);
             case MOD_LOADER_FORGE:
             case MOD_LOADER_NEOFORGE:
             default:
@@ -69,6 +74,7 @@ public class ModLoader {
                 return ForgelikeUtils.FORGE_UTILS.createInstaller(minecraftVersion, modLoaderVersion);
             case MOD_LOADER_QUILT:
             case MOD_LOADER_FABRIC:
+            case MOD_LOADER_LEGACY_FABRIC:
             default:
                 return null;
         }
@@ -85,6 +91,7 @@ public class ModLoader {
                 return true;
             case MOD_LOADER_FABRIC:
             case MOD_LOADER_QUILT:
+            case MOD_LOADER_LEGACY_FABRIC:
             default:
                 return false;
         }

--- a/app_pojavlauncher/src/main/res/layout/fragment_profile_type.xml
+++ b/app_pojavlauncher/src/main/res/layout/fragment_profile_type.xml
@@ -96,6 +96,14 @@
             android:text="@string/modloader_dl_install_quilt_instance" />
 
         <com.kdt.mcgui.MineButton
+            android:id="@+id/modded_profile_legacy_fabric"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/padding_large"
+            android:layout_marginTop="@dimen/padding_large"
+            android:text="@string/modloader_dl_install_legacy_fabric_instance" />
+
+        <com.kdt.mcgui.MineButton
             android:id="@+id/modded_profile_forge"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -430,4 +430,5 @@
     <string name="gr_err_renderer_load_Failed">Ошибка загрузки визуализатора</string>
     <string name="ltw_4x_msaa_warning_msg">Похоже, вы включили настройку \"Включить 4x MSAA\" в разделе \"Для разработчиков\". Пожалуйста отключите её чтобы избежать проблем с визуализацией.</string>
     <string name="no_instance">Не выбрано установки. Пожалуйста создайте установку или выберите существующую.</string>
+    <string name="modloader_dl_install_legacy_fabric_instance">Установка с Legacy Fabric</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -478,4 +478,5 @@
     <string name="runtime_error_title">Runtime not available</string>
     <string name="runtime_error_missing">Java %d is not yet installed. Please choose another compatible runtime or connect to the Internet to install it automatically.</string>
     <string name="runtime_error_install_failed">Failed to install Java %d. Please check your Internet connection and try again.</string>
+    <string name="modloader_dl_install_legacy_fabric_instance">Create Legacy Fabric instance</string>
 </resources>


### PR DESCRIPTION
This pull request adds the ability to install Legacy Fabric from the launcher automatically, and fixes the instance name display as previously it was hard coded to "Fabric".
![Screenshot showing the change](https://github.com/user-attachments/assets/8ac74184-4525-4a4a-82a1-442ae25dab1c)

https://github.com/user-attachments/assets/9f18510c-db92-4e5f-8067-3ee30157139e

