### PR TITLE
Ban Sodium from running on GL4ES core contexts

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
@@ -107,6 +107,20 @@ public class GameRunner {
         return LifecycleAwareAlertDialog.haltOnDialog(activity.getLifecycle(), activity, dialogCreator);
     }
 
+    // Autoswitch to LTW if supported, otherwise - crash with resId dialog message. Returns LTW renderer strings if succeeded
+    private static String switchLtw(boolean hasLtw, Instance instance, AppCompatActivity activity, int resId) throws InterruptedException, IOException {
+        if(hasLtw) {
+            String ltwRenderer = "opengles3_ltw";
+            instance.renderer = ltwRenderer;
+            instance.write();
+            return ltwRenderer;
+        }else {
+            showDialog(activity, resId);
+            System.exit(0);
+            return null;
+        }
+    }
+
     public static void launchMinecraft(final AppCompatActivity activity, MinecraftAccount minecraftAccount,
                                        Instance instance, String versionId, String rendererName) throws Throwable {
         int freeDeviceMemory = Tools.getFreeDeviceMemory(activity);
@@ -141,17 +155,16 @@ public class GameRunner {
             instance.write();
         }
 
-        // Switch renderer to LTW when running 1.21.5
+        boolean isGl4es = rendererName.equals("opengles2");
         boolean ltwSupported = RendererCompatUtil.getCompatibleRenderers(activity).rendererIds.contains("opengles3_ltw");
-        if(!isGl4esCompatible(versionInfo) && rendererName.equals("opengles2")) {
-            if(ltwSupported) {
-                instance.renderer = rendererName = "opengles3_ltw";
-                instance.write();
-            }else {
-                showDialog(activity, R.string.compat_version_not_supported);
-                System.exit(0);
-                return;
-            }
+        // Block Sodium from running with GL4ES on 1.17+
+        if(!isCompatContext(versionInfo) && isGl4es && hasSodium(gamedir)) {
+            rendererName = switchLtw(ltwSupported, instance, activity, R.string.compat_sodium_not_supported);
+        }
+
+        // Switch renderer to LTW when running 1.21.5
+        if(!isGl4esCompatible(versionInfo) && isGl4es) {
+            rendererName = switchLtw(ltwSupported, instance, activity, R.string.compat_version_not_supported);
         }
         RendererCompatUtil.releaseRenderersCache();
 

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -397,6 +397,7 @@
     <string name="modloader_dl_install_forge_instance">Установка с Forge</string>
     <string name="social_media_invite" translatable="false">https://t.me/mojolauncher</string>
     <string name="compat_version_not_supported">Ваше устройство не может запустить эту версию поскольку LTW не поддерживается</string>
+    <string name="compat_sodium_not_supported">Ваше устройство не может запустить Sodium на этой версии поскольку LTW не поддерживается</string>
     <string name="oauth_unknown_error">Неизвестная ошибка авторизации</string>
     <string name="oauth_web_complete">Авторизация…</string>
     <string name="auth_select_microsoft">Аккаунт Microsoft</string>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -440,6 +440,7 @@
     <string name="bta_installer_nightly_versions">Nightly BTA versions</string>
     <string name="newdl_extracting_native_libraries">Extracting native libraries (%d/%d)</string>
     <string name="compat_version_not_supported">Your device cannot run this version because LTW is not supported on your device.</string>
+    <string name="compat_sodium_not_supported">Your device cannot run Sodium on this version because LTW is not supported on your device.</string>
     <string name="oauth_unknown_error">Unknown authentication error</string>
     <string name="oauth_web_complete">Authenticating…</string>
     <string name="auth_select_microsoft">Microsoft account</string>


### PR DESCRIPTION
Sodium is completely broken on 1.17+ with GL4ES, use LTW instead if supported, otherwise - exit with an error message