### PR TITLE
Release nightly builds on GitHub releases

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -53,7 +53,11 @@ jobs:
         run: |
           gradle :app_pojavlauncher:assembleNoruntimeDebug
           mv app_pojavlauncher/build/outputs/apk/noruntime/debug/app_pojavlauncher-noruntime-debug.apk out/app-debug-noruntime.apk
-
+      - name: Build Nightly Release .apk
+        if: github.ref_name == 'v3_openjdk'
+        run: |
+          gradle :app_pojavlauncher:assembleFullPubRelease
+          mv app_pojavlauncher/build/outputs/apk/full/pubRelease/app_pojavlauncher-noruntime-pubRelease.apk out/MojoLauncher-release.apk
       - name: Gen md5sums
         run: |
           md5sum out/app-debug-full.apk > out/app-debug-full.md5
@@ -70,6 +74,19 @@ jobs:
         with:
           name: app-debug-noruntime
           path: out/app-debug-noruntime.apk
+
+      - name: Release Nightly APK
+        if: github.ref_name == 'v3_openjdk'
+        uses: softprops/action-gh-release@v3
+        with:
+          name: MojoLauncher Nightly Builds
+          prerelease: true
+          tag_name: nightly
+          body: |
+            MojoLauncher nightly build.
+            Commit hash: ${{ github.sha }}
+          files: |
+            out/MojoLauncher-release.apk
 
       - name: Upload AAB
         uses: actions/upload-artifact@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -57,7 +57,7 @@ jobs:
         if: github.ref_name == 'v3_openjdk'
         run: |
           gradle :app_pojavlauncher:assembleFullPubRelease
-          mv app_pojavlauncher/build/outputs/apk/full/pubRelease/app_pojavlauncher-noruntime-pubRelease.apk out/MojoLauncher-release.apk
+          mv app_pojavlauncher/build/outputs/apk/full/pubRelease/app_pojavlauncher-full-pubRelease.apk out/MojoLauncher-release.apk
       - name: Gen md5sums
         run: |
           md5sum out/app-debug-full.apk > out/app-debug-full.md5

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -130,6 +130,13 @@ android {
             initWith release
             signingConfig signingConfigs.googlePlayBuild
         }
+        pubRelease {
+            initWith release
+            signingConfig signingConfigs.customDebug // WIP, changeme
+            applicationIdSuffix '.pub'
+            resValue 'string', 'storageProviderAuthorities', 'git.artdeell.mojo.pub.scoped.gamefolder'
+            resValue 'string', 'application_package', 'git.artdeell.mojo.pub'
+        }
     }
 
     ndkVersion = "28.2.13676358"


### PR DESCRIPTION
This PR:
* Adds new build target - pubRelease, used for public release non-GooglePlay builds (i.e. GitHub releases). Implemented as a separate package (`git.artdeell.mojo.pub`), uses different key store and does not share files with GPlay version (sorry, not possible). Uses debug keystore currently for testing.
* Extends current Android CI with Nightly APK builds. These builds are triggered only on v3_openjdk branch, so nightlies should be somewhat stable.

Actual launcher releases are going to be manual with APKs taken from nightly builds.