### PR TITLE
Fix[prefs]: move system Vulkan preference into the renderer category

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceMiscellaneousFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceMiscellaneousFragment.java
@@ -1,22 +1,11 @@
 package net.kdt.pojavlaunch.prefs.screens;
 
-import android.content.pm.PackageManager;
 import android.os.Bundle;
-
-import androidx.preference.Preference;
-
 import git.artdeell.mojo.R;
-
-import net.kdt.pojavlaunch.utils.GLInfoUtils;
-import net.kdt.pojavlaunch.utils.RendererCompatUtil;
 
 public class LauncherPreferenceMiscellaneousFragment extends LauncherPreferenceFragment {
     @Override
     public void onCreatePreferences(Bundle b, String str) {
         addPreferencesFromResource(R.xml.pref_misc);
-        Preference driverPreference = requirePreference("zinkPreferSystemDriver");
-        PackageManager packageManager = driverPreference.getContext().getPackageManager();
-        boolean supportsTurnip = RendererCompatUtil.checkVulkanSupport(packageManager) && GLInfoUtils.getGlInfo().isAdreno();
-        driverPreference.setVisible(supportsTurnip);
     }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceVideoFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceVideoFragment.java
@@ -2,9 +2,11 @@ package net.kdt.pojavlaunch.prefs.screens;
 
 import android.app.Activity;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.preference.ListPreference;
+import androidx.preference.Preference;
 import androidx.preference.SwitchPreference;
 import androidx.preference.SwitchPreferenceCompat;
 
@@ -13,6 +15,7 @@ import git.artdeell.mojo.R;
 import net.kdt.pojavlaunch.plugins.LibraryPlugin;
 import net.kdt.pojavlaunch.prefs.CustomSeekBarPreference;
 import net.kdt.pojavlaunch.prefs.LauncherPreferences;
+import net.kdt.pojavlaunch.utils.GLInfoUtils;
 import net.kdt.pojavlaunch.utils.RendererCompatUtil;
 
 /**
@@ -55,6 +58,11 @@ public class LauncherPreferenceVideoFragment extends LauncherPreferenceFragment 
         RendererCompatUtil.RenderersList renderersList = RendererCompatUtil.getCompatibleRenderers(getContext());
         rendererListPreference.setEntries(renderersList.rendererDisplayNames);
         rendererListPreference.setEntryValues(renderersList.rendererIds.toArray(new String[0]));
+        // Turnip/System Vulkan switch
+        Preference driverPreference = requirePreference("zinkPreferSystemDriver");
+        PackageManager packageManager = driverPreference.getContext().getPackageManager();
+        boolean supportsTurnip = RendererCompatUtil.checkVulkanSupport(packageManager) && GLInfoUtils.getGlInfo().isAdreno();
+        driverPreference.setVisible(supportsTurnip);
 
         computeVisibility();
     }

--- a/app_pojavlauncher/src/main/res/xml/pref_misc.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_misc.xml
@@ -31,12 +31,6 @@
             android:title="@string/preference_verify_manifest_title"
             android:summary="@string/preference_verify_manifest_description"/>
 
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="zinkPreferSystemDriver"
-            android:summary="@string/preference_vulkan_driver_system_description"
-            android:title="@string/preference_vulkan_driver_system_title"/>
-
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app_pojavlauncher/src/main/res/xml/pref_video.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_video.xml
@@ -62,5 +62,10 @@
             android:summary="@string/preference_vsync_in_zink_description"
             android:title="@string/preference_vsync_in_zink_title"
             />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="zinkPreferSystemDriver"
+            android:summary="@string/preference_vulkan_driver_system_description"
+            android:title="@string/preference_vulkan_driver_system_title"/>
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
I'm not sure what does it do in the misc category, it's directly related to rendering/graphics.

Draft because will break due to @Yarpopcat08's incoming PR.