### PR TITLE
Feat[prefs]: add an option to force sysmem rendering on freedreno

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -71,6 +71,8 @@ public class LauncherPreferences {
     public static boolean PREF_RAPID_START = true;
     public static boolean PREF_VERIFY_FILES = true;
 
+    public static boolean PREF_FREEDRENO_SYSMEM = true;
+
 
     public static void loadPreferences(Context ctx) {
         //Required for CTRLDEF_FILE and MultiRT
@@ -113,6 +115,7 @@ public class LauncherPreferences {
         PREF_VSYNC_IN_ZINK = DEFAULT_PREF.getBoolean("vsync_in_zink", true);
         PREF_VERIFY_FILES = DEFAULT_PREF.getBoolean("checkGameFiles", true);
         PREF_RAPID_START = DEFAULT_PREF.getBoolean("fastStartupCheck", true);
+        PREF_FREEDRENO_SYSMEM = DEFAULT_PREF.getBoolean("freedrenoSysmem", false);
 
         String argLwjglLibname = "-Dorg.lwjgl.opengl.libname=";
         for (String arg : JREUtils.parseJavaArguments(PREF_CUSTOM_JAVA_ARGS)) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -71,7 +71,7 @@ public class LauncherPreferences {
     public static boolean PREF_RAPID_START = true;
     public static boolean PREF_VERIFY_FILES = true;
 
-    public static boolean PREF_FREEDRENO_SYSMEM = true;
+    public static boolean PREF_FREEDRENO_SYSMEM = false;
 
 
     public static void loadPreferences(Context ctx) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceExperimentalFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceExperimentalFragment.java
@@ -2,6 +2,10 @@ package net.kdt.pojavlaunch.prefs.screens;
 
 import android.os.Bundle;
 
+import androidx.preference.SwitchPreference;
+
+import net.kdt.pojavlaunch.utils.GLInfoUtils;
+
 import git.artdeell.mojo.R;
 
 public class LauncherPreferenceExperimentalFragment extends LauncherPreferenceFragment {
@@ -9,5 +13,8 @@ public class LauncherPreferenceExperimentalFragment extends LauncherPreferenceFr
     @Override
     public void onCreatePreferences(Bundle b, String str) {
         addPreferencesFromResource(R.xml.pref_experimental);
+        SwitchPreference pref = requirePreference("freedrenoSysmem", SwitchPreference.class);
+        boolean hasFreedreno = GLInfoUtils.getGlInfo().isAdreno();
+        pref.setVisible(hasFreedreno);
     }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -172,6 +172,13 @@ public class JREUtils {
             setUseTurnip(true);
         }
 
+        if(LauncherPreferences.PREF_FREEDRENO_SYSMEM) {
+            // We could also apply the FD_MESA_DEBUG only if freedreno is active but why making things complicated?
+            Logger.appendToLog("Will use sysmem rendering for Turnip/Freedreno");
+            envMap.put("FD_MESA_DEBUG", "sysmem");
+            envMap.put("TU_DEBUG", "sysmem");
+        }
+
         overrideEnvVars(envMap);
 
         for (Map.Entry<String, String> env : envMap.entrySet()) {

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -437,5 +437,5 @@
     <string name="instance_delete_confirmation">Вы уверены что хотите удалить установку? Ваши миры, моды, ресурсы и иные данные находящиеся в папке установки будут удалены. Данное действие не может быть отменено!</string>
     <string name="import_local_modpack">Импорт локальной сборки</string>
     <string name="preference_sysmem_title">Включить принудительную отрисовку в системную память</string>
-    <string name="preference_sysmem_summary">Принуждает Turnip/Freedreno отрисовывать графику только в системную память для исправления некоторых графических проблем. Отключите, если игра стала работать медленною</string>
+    <string name="preference_sysmem_summary">Принуждает Turnip/Freedreno отрисовывать графику только в системную память для исправления некоторых графических проблем. Включите, если игра работает медленно на визуализаторе freedreno.</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -436,4 +436,6 @@
     <string name="instance_delete">Удалить установку</string>
     <string name="instance_delete_confirmation">Вы уверены что хотите удалить установку? Ваши миры, моды, ресурсы и иные данные находящиеся в папке установки будут удалены. Данное действие не может быть отменено!</string>
     <string name="import_local_modpack">Импорт локальной сборки</string>
+    <string name="preference_sysmem_title">Включить принудительную отрисовку в системную память</string>
+    <string name="preference_sysmem_summary">Принуждает Turnip/Freedreno отрисовывать графику только в системную память для исправления некоторых графических проблем. Отключите, если игра стала работать медленною</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -437,5 +437,5 @@
     <string name="instance_delete_confirmation">Вы уверены что хотите удалить установку? Ваши миры, моды, ресурсы и иные данные находящиеся в папке установки будут удалены. Данное действие не может быть отменено!</string>
     <string name="import_local_modpack">Импорт локальной сборки</string>
     <string name="preference_sysmem_title">Включить принудительную отрисовку в системную память</string>
-    <string name="preference_sysmem_summary">Принуждает Turnip/Freedreno отрисовывать графику только в системную память для исправления некоторых графических проблем. Включите, если игра работает медленно на визуализаторе freedreno.</string>
+    <string name="preference_sysmem_summary">Принуждает Turnip/Freedreno отрисовывать графику только в системную память. Включите, если игра работает медленно или вы наблюдаете проблемы отрисовки.</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -485,5 +485,5 @@
     <string name="instance_delete_confirmation">Are you sure you want to delete the instance? This will permanently delete all worlds, mods, resources and any other data in the instance directory. This action cannot be undone!</string>
     <string name="import_local_modpack">Import local modpack</string>
     <string name="preference_sysmem_title">Force rendering into the system memory</string>
-    <string name="preference_sysmem_summary">Forces Freedreno to render directly into the system memory to fix some graphical issues. Disable if the game became slow.</string>
+    <string name="preference_sysmem_summary">Forces Freedreno to render directly into the system memory to fix some graphical issues. Enable if the game is running slow on the freedreno renderer.</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -484,4 +484,6 @@
     <string name="instance_delete">Delete instance</string>
     <string name="instance_delete_confirmation">Are you sure you want to delete the instance? This will permanently delete all worlds, mods, resources and any other data in the instance directory. This action cannot be undone!</string>
     <string name="import_local_modpack">Import local modpack</string>
+    <string name="preference_sysmem_title">Force rendering into the system memory</string>
+    <string name="preference_sysmem_summary">Forces Freedreno to render directly into the system memory to fix some graphical issues. Disable if the game became slow.</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -485,5 +485,5 @@
     <string name="instance_delete_confirmation">Are you sure you want to delete the instance? This will permanently delete all worlds, mods, resources and any other data in the instance directory. This action cannot be undone!</string>
     <string name="import_local_modpack">Import local modpack</string>
     <string name="preference_sysmem_title">Force rendering into the system memory</string>
-    <string name="preference_sysmem_summary">Forces Freedreno to render directly into the system memory to fix some graphical issues. Enable if the game is running slow on the freedreno renderer.</string>
+    <string name="preference_sysmem_summary">Forces Freedreno to render directly into the system memory. Enable if performance is low or you experience rendering issues</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/xml/pref_experimental.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_experimental.xml
@@ -14,6 +14,12 @@
             android:key="bigCoreAffinity"
             android:title="@string/preference_force_big_core_title"
             android:summary="@string/preference_force_big_core_desc" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="freedrenoSysmem"
+            android:title="@string/preference_sysmem_title"
+            android:summary="@string/preference_sysmem_summary"
+            />
 
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Adreno has an on-chip cache memory called GMEM which is used for tiled rendering. On some GPUs (Adreno 830, Adreno 710/720) it works incorrectly causing GPU faults, artifacts and sometimes completely garbled picture. (as reported on MojoLauncher Discord)  

Turnip/Freedreno have an option to force sysmem rendering instead. It's obviously slower than on-chip memory especially on low-end devices, however, on the mentioned GPUs it makes the rendering correct without any noticeable performance loss.

This PR adds a preference to make sysmem forced. It's confirmed to fix issues on at least Adreno 830. The option is located in the experimental settings due to specific of such setting and because it can make Minecraft run VERY SLOW on low-end A6XX/A7XX devices.