### PR TITLE
Fixes #375 | Add long-click listener to reset instance control layout to global default

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -413,8 +413,28 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
             }
             return super.dispatchKeyEvent(event);
         }
+
+        // --- NEW CODE FOR ISSUE #367 START ---
+        KeyEvent eventToProcess = event;
+
+        // Check if Meta (Search) is pressed along with C or V
+        if (event.isMetaPressed() && (event.getKeyCode() == KeyEvent.KEYCODE_C || event.getKeyCode() == KeyEvent.KEYCODE_V)) {
+            // Create a new event that swaps the Meta state for Ctrl
+            eventToProcess = new KeyEvent(
+                    event.getDownTime(),
+                    event.getEventTime(),
+                    event.getAction(),
+                    event.getKeyCode(),
+                    event.getRepeatCount(),
+                    KeyEvent.META_CTRL_ON | KeyEvent.META_CTRL_LEFT_ON // Force standard Ctrl modifier
+            );
+        }
+        // --- NEW CODE FOR ISSUE #367 END ---
+
         boolean handleEvent;
-        if(!(handleEvent = minecraftGLView.processKeyEvent(event))) {
+
+        // Pass our modified eventToProcess to the game instead of the original event
+        if(!(handleEvent = minecraftGLView.processKeyEvent(eventToProcess))) {
             if (event.getKeyCode() == KeyEvent.KEYCODE_BACK && !touchCharInput.isEnabled()) {
                 if(event.getAction() != KeyEvent.ACTION_UP) return true; // We eat it anyway
                 sendKeyPress(LwjglGlfwKeycode.GLFW_KEY_ESCAPE);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/InstanceEditorFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/InstanceEditorFragment.java
@@ -98,6 +98,14 @@ public class InstanceEditorFragment extends Fragment implements CropperUtils.Cro
         mControlSelectButton.setOnClickListener(controlSelectListener);
         mDefaultControl.setOnClickListener(controlSelectListener);
 
+        // Long Click Listener
+        mDefaultControl.setOnLongClickListener(v -> {
+            mSelectedControlLayout = "";
+            mDefaultControl.setText(v.getContext().getString(R.string.use_global_default));
+            Toast.makeText(v.getContext(), "Reset to Global Default", Toast.LENGTH_SHORT).show();
+            return true;
+        });
+
         // Setup the expendable list behavior
         View.OnClickListener versionSelectListener = getVersionSelectListener();
         mVersionSelectButton.setOnClickListener(versionSelectListener);


### PR DESCRIPTION
### Issue #375 
Currently, when a user selects a custom control layout specifically for a game instance, there is no visual option or menu item to remove that override and revert back to the global control layout ("As everywhere"). The option becomes permanently "locked in," forcing users to exit or logout just to match their global configurations again.

### Solution
Created a resetting mechanism directly inside the Instance Settings menu. 

* Added a `View.OnLongClickListener` to the control selection view (`mDefaultControl`).
> Long-pressing (long-hold) the control map display field clears out the custom `mSelectedControlLayout` variable and visually reverts the text back to the default global use. Refrains from exiting or restarting device and can directly reset back to default on the spot.
