### PR TITLE
Feat[zink]: load legacy Mesa if ARM Mali

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -62,6 +62,7 @@ public class LauncherPreferences {
     public static float PREF_DEADZONE_SCALE = 1f;
     public static boolean PREF_BIG_CORE_AFFINITY = false;
     public static boolean PREF_ZINK_PREFER_SYSTEM_DRIVER = false;
+    public static boolean PREF_ZINK_FORCE_LEGACY = false;
     
     public static boolean PREF_VERIFY_MANIFEST = true;
     public static String PREF_DOWNLOAD_SOURCE = "default";
@@ -113,6 +114,8 @@ public class LauncherPreferences {
         PREF_VSYNC_IN_ZINK = DEFAULT_PREF.getBoolean("vsync_in_zink", true);
         PREF_VERIFY_FILES = DEFAULT_PREF.getBoolean("checkGameFiles", true);
         PREF_RAPID_START = DEFAULT_PREF.getBoolean("fastStartupCheck", true);
+
+        PREF_ZINK_FORCE_LEGACY = DEFAULT_PREF.getBoolean("zinkForceLegacy", false);
 
         String argLwjglLibname = "-Dorg.lwjgl.opengl.libname=";
         for (String arg : JREUtils.parseJavaArguments(PREF_CUSTOM_JAVA_ARGS)) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceVideoFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceVideoFragment.java
@@ -43,6 +43,7 @@ public class LauncherPreferenceVideoFragment extends LauncherPreferenceFragment 
 
         requirePreference("alternate_surface", SwitchPreferenceCompat.class).setChecked(LauncherPreferences.PREF_USE_ALTERNATE_SURFACE);
         requirePreference("force_vsync", SwitchPreferenceCompat.class).setChecked(LauncherPreferences.PREF_FORCE_VSYNC);
+        requirePreference("zinkForceLegacy", SwitchPreference.class).setChecked(LauncherPreferences.PREF_ZINK_FORCE_LEGACY);
 
         // Show ANGLE switch only if AnglePlugin is available
         LibraryPlugin angle = LibraryPlugin.discoverPlugin(getContext(), LibraryPlugin.ID_ANGLE_PLUGIN);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -108,6 +108,9 @@ public class JREUtils {
                 // HACK: GLSL version override for Mesa-based renderers (i.e. Zink)
                 // Required to run the game properly on some mobile Vulkan drivers (Minecraft fails to compile shaders without)
                 envMap.put("MESA_GLSL_VERSION_OVERRIDE", "460");
+                // Mali additionally wants this
+                if(GLInfoUtils.getGlInfo().isArm())
+                    envMap.put("MESA_GL_VERSION_OVERRIDE", "3.3");
                 break;
             case "freedreno_kgsl":
                 if(GLInfoUtils.getGlInfo().isAdreno()) {
@@ -161,6 +164,7 @@ public class JREUtils {
         }
         setupFfmpegEnv(context, envMap);
         setupRendererEnv(envMap, renderer);
+
 
         // HACK
         envMap.put("POJAV_NATIVEDIR", Tools.NATIVE_LIB_DIR);
@@ -254,24 +258,29 @@ public class JREUtils {
      */
     public static String loadGraphicsLibrary(String renderer){
         String renderLibrary;
-        boolean useGles;
+        boolean useGles, useGlapi = false;
         boolean bypassNamespace = false;
-        boolean preloadVk = true;
         int glesVersion;
         switch (renderer){
             case "freedreno_kgsl":
-                preloadVk = false;
             case "vulkan_zink":
-                renderLibrary = "libEGL_mesa.so";
+                // On Mali Mesa performs better with legacy zink
+                if(GLInfoUtils.getGlInfo().isArm()){
+                    useGlapi = true;
+                    renderLibrary = "libEGL_legacy.so";
+                } else renderLibrary = "libEGL_mesa.so";
                 useGles = false;
                 bypassNamespace = true; // Mesa is linked to a bunch of libraries not available in the pojavexec namespace
                 glesVersion = 3;
-                if(preloadVk) preloadVulkan(); // Zink requires Vulkan library to be preloaded
                 break;
             case "opengles3_ltw" :
                 renderLibrary = "libltw.so";
                 useGles = true;
                 glesVersion = 3;
+                // Allow ANGLE to use custom Vulkan library by running LTW (and thus ANGLE too) in the same namespace as the driver
+                if(LauncherPreferences.PREF_USE_ANGLE && !PREF_ZINK_PREFER_SYSTEM_DRIVER) {
+                    bypassNamespace = true;
+                }
                 break;
             case "opengles2":
             case "opengles2_5":
@@ -282,8 +291,7 @@ public class JREUtils {
                 glesVersion = Integer.parseInt((String) ExtraCore.getValue(ExtraConstants.OPEN_GL_VERSION));
                 break;
         }
-
-        if (!configureRenderspec(renderLibrary, bypassNamespace, useGles, glesVersion)) {
+        if (!configureRenderspec(renderLibrary, bypassNamespace, useGlapi, useGles, glesVersion)) {
             Log.e("RENDER_LIBRARY","Failed to load renderer " + renderLibrary );
             return null;
         }
@@ -296,7 +304,7 @@ public class JREUtils {
     public static native int chdir(String path);
 
     public static native void setLdLibraryPath(String ldLibraryPath);
-    public static native boolean configureRenderspec(String eglPath, boolean useLoaderBypass, boolean useGles, int glesVersion);
+    public static native boolean configureRenderspec(String eglPath, boolean useLoaderBypass, boolean useGlapi, boolean useGles, int glesVersion);
     public static native void preloadVulkan();
     public static native void setUseTurnip(boolean enable);
     //public static native void initializeHooks();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -109,7 +109,7 @@ public class JREUtils {
                 // Required to run the game properly on some mobile Vulkan drivers (Minecraft fails to compile shaders without)
                 envMap.put("MESA_GLSL_VERSION_OVERRIDE", "460");
                 // Mali additionally wants this
-                if(GLInfoUtils.getGlInfo().isArm())
+                if(LauncherPreferences.PREF_ZINK_FORCE_LEGACY || GLInfoUtils.getGlInfo().isArm())
                     envMap.put("MESA_GL_VERSION_OVERRIDE", "3.3");
                 break;
             case "freedreno_kgsl":
@@ -265,7 +265,7 @@ public class JREUtils {
             case "freedreno_kgsl":
             case "vulkan_zink":
                 // On Mali Mesa performs better with legacy zink
-                if(GLInfoUtils.getGlInfo().isArm()){
+                if(LauncherPreferences.PREF_ZINK_FORCE_LEGACY || GLInfoUtils.getGlInfo().isArm()){
                     useGlapi = true;
                     renderLibrary = "libEGL_legacy.so";
                 } else renderLibrary = "libEGL_mesa.so";

--- a/app_pojavlauncher/src/main/jni/minibridge.c
+++ b/app_pojavlauncher/src/main/jni/minibridge.c
@@ -40,6 +40,7 @@ static void* egl_acquire_default(const char* name) {
 JNIEXPORT jboolean JNICALL
 Java_net_kdt_pojavlaunch_utils_JREUtils_configureRenderspec(JNIEnv *env, jclass clazz,
                                                             jstring eglPath, jboolean use_loader_bypass,
+                                                            jboolean use_glapi,
                                                             jboolean use_gles,
                                                             jint gles_version) {
     if(eglPath != NULL) {
@@ -58,7 +59,9 @@ Java_net_kdt_pojavlaunch_utils_JREUtils_configureRenderspec(JNIEnv *env, jclass 
         } else {
             renderspec.egl_acquire = egl_acquire_default;
         }
-
+        // Old Mesa versions used glapi and didn't support building without it with EGL enabled
+        // Yet for some reason they can't find it so let's load it ourselves
+        if(use_glapi) renderspec.egl_acquire("libglapi.so");
         void* egl_handle = renderspec.egl_acquire(renderspec.egl_path);
         if(!egl_handle) {
             printf("Failed to load EGL: %s\n", dlerror());

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -187,6 +187,8 @@
     <string name="preference_force_vsync_description">Уменьшает перегрев устройства за счёт ограничения максимальной производительности.</string>
     <string name="preference_use_angle_title">Использовать ANGLE</string>
     <string name="preference_use_angle_description">Позволяет использовать ANGLE вместо системного драйвера для LTW. Может исправить некоторые графические проблемы при использовании модов на некоторых видеоядрах</string>
+    <string name="preference_force_legacy_zink_title">Принудительно использовать старый Zink</string>
+    <string name="preference_force_legacy_zink_description">Включает принудительное использование старой версии Zink вне зависимости от текущего устройства. Может исправить некоторые графические проблемы. Выключите, если игра стала работать медленно.</string>
     <string name="preference_force_english_title">Принудительно включить английский</string>
     <string name="preference_force_english_description">Позволяет увидеть оригинальные строки такими, какими их задумали разработчики. Требуется перезапуск.</string>
     <string name="preference_edit_controls_title">Изменить раскладку</string>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -213,6 +213,8 @@
     <string name="preference_force_vsync_description">Limit thermal throttling by limiting peak performance.</string>
     <string name="preference_use_angle_title">Use ANGLE</string>
     <string name="preference_use_angle_description">Allows using ANGLE instead of the system driver for LTW. Can fix graphical issues with mods on some GPUs</string>
+    <string name="preference_force_legacy_zink_title">Use legacy Zink</string>
+    <string name="preference_force_legacy_zink_description">Forcefully use legacy Zink instead of selecting it depending on the current device. Might fix some graphical issues. Disable if the game became slow.</string>
     <string name="preference_force_english_title">Force language to English</string>
     <string name="preference_force_english_description">Allows you to see original strings, as intended by developers. Requires a restart.</string>
     <string name="preference_edit_controls_title">Edit custom controls</string>

--- a/app_pojavlauncher/src/main/res/xml/pref_video.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_video.xml
@@ -62,5 +62,11 @@
             android:summary="@string/preference_vsync_in_zink_description"
             android:title="@string/preference_vsync_in_zink_title"
             />
+        <SwitchPreference
+            android:title="@string/preference_force_legacy_zink_title"
+            android:summary="@string/preference_force_legacy_zink_description"
+            android:key="zinkForceLegacy"
+            android:defaultValue="false"
+            />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Zink on Mesa 26.1 does not support legacy ARM blob anymore. This brings support for loading another Mesa build specifically for Mali. Other GPUs (PowerVR/Xclipse/Adreno) continue using 26.1

Mesa 23.0.4 is known to be working correctly. Binaries are not included.