### PR TITLE
Integrate ANGLE natively, drop support for ANGLE plugin

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,6 +27,15 @@ jobs:
           name: output-aar
           path: app_pojavlauncher/libs
 
+      - name: Get ANGLE
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          name: angle-aar
+          path: app_pojavlauncher/libs
+          repo: MojoLauncher/angle-builder
+          workflow: blank.yml
+          workflow_conclusion: success
+
       - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: "8.14.3"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ app_pojavlauncher/.cxx/
 .vs/
 /curseforge_key.txt
 /app_pojavlauncher/libs/ltw-release.aar
+/app_pojavlauncher/libs/angle.aar

--- a/app_pojavlauncher/src/main/AndroidManifest.xml
+++ b/app_pojavlauncher/src/main/AndroidManifest.xml
@@ -135,6 +135,5 @@
     </application>
     <queries>
         <package android:name="git.mojo.ffmpeg"/>
-        <package android:name="git.mojo.angle"/>
     </queries>
 </manifest>

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/plugins/LibraryPlugin.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/plugins/LibraryPlugin.java
@@ -6,14 +6,11 @@ import android.content.pm.PackageManager;
 import android.util.Log;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 
 public class LibraryPlugin {
     private static final String TAG = "LibraryPlugin";
 
     // Known plugins constants
-    public static final String ID_ANGLE_PLUGIN = "git.mojo.angle";
     public static final String ID_FFMPEG_PLUGIN = "git.mojo.ffmpeg";
 
     private String appId;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceVideoFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceVideoFragment.java
@@ -9,8 +9,6 @@ import androidx.preference.SwitchPreference;
 import androidx.preference.SwitchPreferenceCompat;
 
 import git.artdeell.mojo.R;
-
-import net.kdt.pojavlaunch.plugins.LibraryPlugin;
 import net.kdt.pojavlaunch.prefs.CustomSeekBarPreference;
 import net.kdt.pojavlaunch.prefs.LauncherPreferences;
 import net.kdt.pojavlaunch.utils.RendererCompatUtil;
@@ -45,9 +43,8 @@ public class LauncherPreferenceVideoFragment extends LauncherPreferenceFragment 
         requirePreference("force_vsync", SwitchPreferenceCompat.class).setChecked(LauncherPreferences.PREF_FORCE_VSYNC);
 
         // Show ANGLE switch only if AnglePlugin is available
-        LibraryPlugin angle = LibraryPlugin.discoverPlugin(getContext(), LibraryPlugin.ID_ANGLE_PLUGIN);
         SwitchPreferenceCompat angleSwitch = requirePreference("use_angle", SwitchPreferenceCompat.class);
-        angleSwitch.setVisible(angle != null);
+        angleSwitch.setVisible(RendererCompatUtil.appHasAngleEGL);
         angleSwitch.setChecked(LauncherPreferences.PREF_USE_ANGLE);
 
         ListPreference rendererListPreference = requirePreference("renderer",

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -82,15 +82,12 @@ public class JREUtils {
     // Sets up ANGLE driver environment
     public static void setupAngleEnv(Context ctx, Map<String, String> envMap) {
         if (!LauncherPreferences.PREF_USE_ANGLE) return;
-        LibraryPlugin angle = LibraryPlugin.discoverPlugin(ctx, LibraryPlugin.ID_ANGLE_PLUGIN);
-        if (angle == null) return;
-        String[] angleLibs = {"libEGL_angle.so", "libGLESv2_angle.so"};
-        if (!angle.checkLibraries(angleLibs)) {
-            Log.e("AngleEnvSetup", "AnglePlugin exists, but the ANGLE libraries are not present. Is the plugin corrupted?");
+        if (!RendererCompatUtil.appHasAngleEGL) {
+            Log.e("AngleEnvSetup", "The ANGLE libraries are not present.");
             return;
         }
-        envMap.put("LIBGL_EGL", angle.resolveAbsolutePath(angleLibs[0]));
-        envMap.put("LIBGL_GLES", angle.resolveAbsolutePath(angleLibs[1]));
+        envMap.put("LIBGL_EGL", "libEGL_angle.so");
+        envMap.put("LIBGL_GLES", "libGLESv2_angle.so");
     }
 
     public static void setupFfmpegEnv(Context ctx, Map<String, String> envMap) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/RendererCompatUtil.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/RendererCompatUtil.java
@@ -75,4 +75,6 @@ public class RendererCompatUtil {
             this.rendererDisplayNames = rendererDisplayNames;
         }
     }
+
+    public static boolean appHasAngleEGL = new File(Tools.NATIVE_LIB_DIR,"libEGL_angle.so").exists();
 }


### PR DESCRIPTION
This pull request drops support for the Mojo ANGLE plugin in favour of having the libs in the launcher natively. ANGLE libraries are still an optional component, the launcher should be able to be built and function without them (untested). I also changed the android.yml workflow file to download the latest action build of MojoLauncher's ANGLE, so the launcher ships with it by default.