### PR TITLE
feat[README] add nightly.link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 You can get MojoLauncher via three methods:
 
-1. You can get the prebuilt app from [automatic builds](https://github.com/MojoLauncher/MojoLauncher/actions).
+1. You can get the latest prebuilt app from [nightly.link](https://nightly.link/MojoLauncher/MojoLauncher/workflows/android/v3_openjdk?preview) or select from [automatic builds](https://github.com/MojoLauncher/MojoLauncher/actions).
 
 2. You can get it from Google Play by clicking on this badge:
 [![Google Play](https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png)](https://play.google.com/store/apps/details?id=git.artdeell.mojo)


### PR DESCRIPTION
This pr adds nightly.link to the README, allowing users without a GitHub account to download the latest pre-built app without having to raid the Discord server or visit scam/fake websites, ouch!