### PR TITLE
Fix[custom_controls]: check if layout parent is null

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlInterface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlInterface.java
@@ -73,9 +73,9 @@ public interface ControlInterface extends View.OnLongClickListener, GrabListener
 
     @Override
     default void onGrabState(boolean isGrabbing) {
-        if (getControlLayoutParent() != null && getControlLayoutParent().getModifiable()) return; // Disable when edited
-        setVisible(((getProperties().displayInGame && isGrabbing) || (getProperties().displayInMenu && !isGrabbing)) &&
-                getControlLayoutParent() != null && getControlLayoutParent().areControlVisible());
+        if (getControlLayoutParent() == null || getControlLayoutParent().getModifiable()) return; // Disable when edited
+        setVisible(((getProperties().displayInGame && isGrabbing) || (getProperties().displayInMenu && !isGrabbing))
+                && getControlLayoutParent().areControlVisible());
     }
 
     default ControlLayout getControlLayoutParent() {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlInterface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlInterface.java
@@ -74,7 +74,8 @@ public interface ControlInterface extends View.OnLongClickListener, GrabListener
     @Override
     default void onGrabState(boolean isGrabbing) {
         if (getControlLayoutParent() != null && getControlLayoutParent().getModifiable()) return; // Disable when edited
-        setVisible(((getProperties().displayInGame && isGrabbing) || (getProperties().displayInMenu && !isGrabbing)) && getControlLayoutParent().areControlVisible());
+        setVisible(((getProperties().displayInGame && isGrabbing) || (getProperties().displayInMenu && !isGrabbing)) &&
+                getControlLayoutParent() != null && getControlLayoutParent().areControlVisible());
     }
 
     default ControlLayout getControlLayoutParent() {


### PR DESCRIPTION
This fixes a REAL launcher crash and additionally brings back buttons that should display only if the cursor is grabbed