### PR TITLE
Feat[jre]: remove now useless startup flags

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/JavaRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/JavaRunner.java
@@ -117,13 +117,9 @@ public class JavaRunner {
                 //"-Dorg.lwjgl.util.Debug=true",
                 //"-Dorg.lwjgl.util.DebugFunctions=true",
                 //"-Dorg.lwjgl.util.DebugLoader=true",
-                // GLFW Stub width height
-                "-Dglfwstub.initEgl=false",
                 "-Dext.net.resolvPath=" +resolvFile,
                 "-Dlog4j2.formatMsgNoLookups=true", //Log4j RCE mitigation
-                "-Dfml.earlyprogresswindow=false", //Forge 1.14+ workaround
                 "-Dloader.disable_forked_guis=true",
-                "-Dsodium.checks.issue2561=false",
                 "-Djdk.lang.Process.launchMechanism=FORK" // Default is POSIX_SPAWN which requires starting jspawnhelper, which doesn't work on Android
         ));
         List<String> additionalArguments = new ArrayList<>();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/JavaRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/JavaRunner.java
@@ -119,6 +119,7 @@ public class JavaRunner {
                 //"-Dorg.lwjgl.util.DebugLoader=true",
                 "-Dext.net.resolvPath=" +resolvFile,
                 "-Dlog4j2.formatMsgNoLookups=true", //Log4j RCE mitigation
+                "-Dfml.earlyprogresswindow=false", //Forge 1.14+ workaround
                 "-Dloader.disable_forked_guis=true",
                 "-Djdk.lang.Process.launchMechanism=FORK" // Default is POSIX_SPAWN which requires starting jspawnhelper, which doesn't work on Android
         ));


### PR DESCRIPTION
Removes some JRE startup arguments which are not needed on new Mojo anymore:

* `-Dglfwstub.initEgl=false` – glfwstub was removed completely;  
* `-Dfml.earlyprogresswindow=false` – proper GLFW implementation fixed this issue, the window now appears properly and doesn't crash the game;
* `-Dsodium.checks.issue2561=false` – we use real LWJGL with the same version as used by the current Minecraft version, no need to bypass that Sodium check in this case.

