### PR TITLE
Feat[surface]: implement keyboard panning

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -166,7 +166,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
             int translationY;
             // Autopanning (if keyboardPan wasn't clicked)
             if(!mDoPanning) {
-                int cursorY = (int) (GLFW.cursorY * minecraftGLView.mSurface.getHeight());
+                int cursorY = (int) (GLFW.cursorY * minecraftGLView.mSurface.getHeight()) + 100;
                 translationY = Tools.getTranslationFromCursorY(
                         cursorY,
                         minecraftGLView.mSurface.getHeight(),

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -84,7 +84,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
     public static TouchCharInput touchCharInput;
     private MinecraftGLSurface minecraftGLView;
     private static WeakReference<GLFWCursorView> weakCursor;
-    public GLFWCursorView cursor;
+    private GLFWCursorView cursor;
     private LoggerView loggerView;
     private DrawerLayout drawerLayout;
     private ListView navDrawer;
@@ -136,13 +136,11 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
             getWindow().setSustainedPerformanceMode(PREF_SUSTAINED_PERFORMANCE);
 
-        // Make keyboard pan the activity so the user sees what they're typing
-        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
         // This is required on Android 10 for the insets listener
         // https://issuetracker.google.com/issues/266331465
         if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q)
             getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
-
+        // Make keyboard pan the activity so the user sees what they're typing
         ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), (view, insets) -> {
             if(minecraftGLView.mSurface == null)
                 return insets;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -24,6 +24,7 @@ import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewPropertyAnimator;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
@@ -100,6 +101,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
     private GameService.LocalBinder mServiceBinder;
 
     private QuickSettingSideDialog mQuickSettingSideDialog;
+    private static boolean mDoPanning = false;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -134,12 +136,18 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), (view, insets) -> {
             if(minecraftGLView.mSurface == null)
                 return insets;
+            ViewPropertyAnimator anim = minecraftGLView.mSurface.animate()
+                    .setDuration(100);
             boolean imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
+            if(!imeVisible){
+                anim.translationY(0).start();
+                return insets;
+            }
+            if(!mDoPanning)
+                return insets;
             int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
-            minecraftGLView.mSurface.animate()
-                    .translationY(imeVisible ? -imeHeight : 0)
-                    .setDuration(100)
-                    .start();
+            anim.translationY(-imeHeight).start();
+            mDoPanning = false;
             return insets;
         });
 
@@ -451,8 +459,11 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         return handleEvent;
     }
 
-    public static void switchKeyboardState() {
-        if(touchCharInput != null) touchCharInput.switchKeyboardState();
+    public static void switchKeyboardState(boolean panning) {
+        if(touchCharInput != null) {
+            MainActivity.mDoPanning = panning;
+            touchCharInput.switchKeyboardState();
+        }
     }
 
     @Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -153,6 +153,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
                 animCursor.translationY(0).start();
                 mImeHeight = 0;
                 if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+                    // AndroidX keeps SystemUI visible for some reason after IME session
                     view.postDelayed(() -> {
                         view.setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY | View.SYSTEM_UI_FLAG_FULLSCREEN);
                     }, 150);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -25,6 +25,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewPropertyAnimator;
+import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
@@ -34,6 +35,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 
@@ -132,8 +134,14 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
             getWindow().setSustainedPerformanceMode(PREF_SUSTAINED_PERFORMANCE);
 
-        // Make keyboard pan the activity so the user sees what they're typing in
+        // Make keyboard pan the activity so the user sees what they're typing
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        // This is required on Android 10 for the insets listener
+        // https://issuetracker.google.com/issues/266331465
+        if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q)
+            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), (view, insets) -> {
+            Log.i("InsetListener", "Executing listener");
             if(minecraftGLView.mSurface == null)
                 return insets;
             ViewPropertyAnimator anim = minecraftGLView.mSurface.animate()

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -161,7 +161,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
                 if(cursorY < visibleHeight)
                     return insets;
                 final int padding = 50;
-                int translationY = cursorY - visibleHeight + padding;
+                int translationY = Math.min(imeHeight, cursorY - visibleHeight + padding);
                 anim.translationY(-translationY).start();
                 return insets;
             }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -151,7 +151,10 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
                 anim.translationY(0).start();
                 return insets;
             }
+            if(!mDoPanning && !LauncherPreferences.PREF_KEYBOARD_AUTOPANNING)
+                return insets;
             int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+            // Autopanning (if keyboardPan wasn't clicked)
             if(!mDoPanning) {
                 int cursorY = minecraftGLView.touchLastY;
                 int visibleHeight = minecraftGLView.mSurface.getHeight() - imeHeight;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -174,7 +174,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
                         cursorY,
                         minecraftGLView.mSurface.getHeight(),
                         mImeHeight,
-                        50
+                        0
                 );
             } else
                 translationY = mImeHeight;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -105,6 +105,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
 
     private QuickSettingSideDialog mQuickSettingSideDialog;
     private static boolean mDoPanning = false;
+    public static int mImeHeight = 0;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -149,23 +150,25 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
                     .setDuration(100);
             if(!insets.isVisible(WindowInsetsCompat.Type.ime())){
                 anim.translationY(0).start();
+                mImeHeight = 0;
                 return insets;
             }
             if(!mDoPanning && !LauncherPreferences.PREF_KEYBOARD_AUTOPANNING)
                 return insets;
-            int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+            mImeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
             // Autopanning (if keyboardPan wasn't clicked)
             if(!mDoPanning) {
                 int cursorY = (int) (GLFW.cursorY * minecraftGLView.mSurface.getHeight());
-                int visibleHeight = minecraftGLView.mSurface.getHeight() - imeHeight;
-                if(cursorY < visibleHeight)
-                    return insets;
-                final int padding = 50;
-                int translationY = Math.min(imeHeight, cursorY - visibleHeight + padding);
+                int translationY = Tools.getTranslationFromCursorY(
+                        cursorY,
+                        minecraftGLView.mSurface.getHeight(),
+                        mImeHeight,
+                        50
+                );
                 anim.translationY(-translationY).start();
                 return insets;
             }
-            anim.translationY(-imeHeight).start();
+            anim.translationY(-mImeHeight).start();
             return insets;
         });
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -32,6 +32,8 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 
 import com.kdt.LoggerView;
@@ -127,6 +129,19 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         // Set the sustained performance mode for available APIs
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
             getWindow().setSustainedPerformanceMode(PREF_SUSTAINED_PERFORMANCE);
+
+        // Make keyboard pan the activity so the user sees what they're typing in
+        ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), (view, insets) -> {
+            if(minecraftGLView.mSurface == null)
+                return insets;
+            boolean imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
+            int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+            minecraftGLView.mSurface.animate()
+                    .translationY(imeVisible ? -imeHeight : 0)
+                    .setDuration(100)
+                    .start();
+            return insets;
+        });
 
         ingameControlsEditorArrayAdapter = new ArrayAdapter<>(this,
                 android.R.layout.simple_list_item_1, getResources().getStringArray(R.array.menu_customcontrol));

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -84,7 +84,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
     public static TouchCharInput touchCharInput;
     private MinecraftGLSurface minecraftGLView;
     private static WeakReference<GLFWCursorView> weakCursor;
-    private GLFWCursorView cursor;
+    public GLFWCursorView cursor;
     private LoggerView loggerView;
     private DrawerLayout drawerLayout;
     private ListView navDrawer;
@@ -146,29 +146,33 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), (view, insets) -> {
             if(minecraftGLView.mSurface == null)
                 return insets;
-            ViewPropertyAnimator anim = minecraftGLView.mSurface.animate()
+            ViewPropertyAnimator animSurface = minecraftGLView.mSurface.animate()
+                    .setDuration(100);
+            ViewPropertyAnimator animCursor = cursor.animate()
                     .setDuration(100);
             if(!insets.isVisible(WindowInsetsCompat.Type.ime())){
-                anim.translationY(0).start();
+                animSurface.translationY(0).start();
+                animCursor.translationY(0).start();
                 mImeHeight = 0;
                 return insets;
             }
             if(!mDoPanning && !LauncherPreferences.PREF_KEYBOARD_AUTOPANNING)
                 return insets;
             mImeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+            int translationY;
             // Autopanning (if keyboardPan wasn't clicked)
             if(!mDoPanning) {
                 int cursorY = (int) (GLFW.cursorY * minecraftGLView.mSurface.getHeight());
-                int translationY = Tools.getTranslationFromCursorY(
+                translationY = Tools.getTranslationFromCursorY(
                         cursorY,
                         minecraftGLView.mSurface.getHeight(),
                         mImeHeight,
                         50
                 );
-                anim.translationY(-translationY).start();
-                return insets;
-            }
-            anim.translationY(-mImeHeight).start();
+            } else
+                translationY = mImeHeight;
+            animSurface.translationY(-translationY).start();
+            animCursor.translationY(-translationY).start();
             return insets;
         });
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -73,6 +73,7 @@ import java.util.Objects;
 
 import git.artdeell.dnbootstrap.glfw.AndroidClipboardProvider;
 import git.artdeell.dnbootstrap.glfw.GLFW;
+import git.artdeell.dnbootstrap.glfw.GLFWCursor;
 import git.artdeell.dnbootstrap.glfw.GLFWCursorView;
 import git.artdeell.mojo.R;
 
@@ -140,6 +141,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         // https://issuetracker.google.com/issues/266331465
         if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q)
             getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+
         ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), (view, insets) -> {
             if(minecraftGLView.mSurface == null)
                 return insets;
@@ -149,10 +151,18 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
                 anim.translationY(0).start();
                 return insets;
             }
-            if(!mDoPanning)
+            int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+            if(!mDoPanning) {
+                int cursorY = minecraftGLView.touchLastY;
+                int visibleHeight = minecraftGLView.mSurface.getHeight() - imeHeight;
+                if(cursorY < visibleHeight)
+                    return insets;
+                final int padding = 50;
+                int translationY = cursorY - visibleHeight + padding;
+                anim.translationY(-translationY).start();
                 return insets;
-            anim.translationY(-insets.getInsets(WindowInsetsCompat.Type.ime()).bottom).start();
-            mDoPanning = false;
+            }
+            anim.translationY(-imeHeight).start();
             return insets;
         });
 
@@ -466,8 +476,8 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
 
     public static void switchKeyboardState(boolean panning) {
         if(touchCharInput != null) {
-            MainActivity.mDoPanning = panning;
             touchCharInput.switchKeyboardState();
+            MainActivity.mDoPanning = panning;
         }
     }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -35,7 +35,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 
@@ -73,7 +72,6 @@ import java.util.Objects;
 
 import git.artdeell.dnbootstrap.glfw.AndroidClipboardProvider;
 import git.artdeell.dnbootstrap.glfw.GLFW;
-import git.artdeell.dnbootstrap.glfw.GLFWCursor;
 import git.artdeell.dnbootstrap.glfw.GLFWCursorView;
 import git.artdeell.mojo.R;
 
@@ -105,7 +103,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
 
     private QuickSettingSideDialog mQuickSettingSideDialog;
 
-    public static boolean mDoPanning = false;
+    public static boolean mForceFullPanning = false;
     public static int mImeHeight = 0;
 
     @Override
@@ -139,7 +137,8 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
 
         // This is required on Android 10 for the insets listener
         // https://issuetracker.google.com/issues/266331465
-        if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q)
+        boolean androidCompat = Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q;
+        if(androidCompat)
             getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         // Make keyboard pan the activity so the user sees what they're typing
         ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), (view, insets) -> {
@@ -153,7 +152,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
                 animSurface.translationY(0).start();
                 animCursor.translationY(0).start();
                 mImeHeight = 0;
-                if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+                if(androidCompat) {
                     // AndroidX keeps SystemUI visible for some reason after IME session
                     view.postDelayed(() -> {
                         view.setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY | View.SYSTEM_UI_FLAG_FULLSCREEN);
@@ -161,12 +160,12 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
                 }
                 return insets;
             }
-            if(!mDoPanning && !LauncherPreferences.PREF_KEYBOARD_AUTOPANNING)
+            if(!mForceFullPanning && !LauncherPreferences.PREF_KEYBOARD_AUTOPANNING)
                 return insets;
             mImeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
             int translationY;
             // Autopanning (if keyboardPan wasn't clicked)
-            if(!mDoPanning) {
+            if(!mForceFullPanning) {
                 int cursorY = (int) (GLFW.cursorY * minecraftGLView.mSurface.getHeight()) + 100;
                 translationY = Tools.getTranslationFromCursorY(
                         cursorY,
@@ -492,7 +491,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
     public static void switchKeyboardState(boolean panning) {
         if(touchCharInput != null) {
             touchCharInput.switchKeyboardState();
-            MainActivity.mDoPanning = panning;
+            MainActivity.mForceFullPanning = panning;
         }
     }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -154,11 +154,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
                 mImeHeight = 0;
                 if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
                     view.postDelayed(() -> {
-                        view.setSystemUiVisibility(
-                                View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
-                                        View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY |
-                                        View.SYSTEM_UI_FLAG_FULLSCREEN
-                        );
+                        view.setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY | View.SYSTEM_UI_FLAG_FULLSCREEN);
                     }, 150);
                 }
                 return insets;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -152,6 +152,15 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
                 animSurface.translationY(0).start();
                 animCursor.translationY(0).start();
                 mImeHeight = 0;
+                if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+                    view.postDelayed(() -> {
+                        view.setSystemUiVisibility(
+                                View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
+                                        View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY |
+                                        View.SYSTEM_UI_FLAG_FULLSCREEN
+                        );
+                    }, 150);
+                }
                 return insets;
             }
             if(!mDoPanning && !LauncherPreferences.PREF_KEYBOARD_AUTOPANNING)

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -141,20 +141,17 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q)
             getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), (view, insets) -> {
-            Log.i("InsetListener", "Executing listener");
             if(minecraftGLView.mSurface == null)
                 return insets;
             ViewPropertyAnimator anim = minecraftGLView.mSurface.animate()
                     .setDuration(100);
-            boolean imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
-            if(!imeVisible){
+            if(!insets.isVisible(WindowInsetsCompat.Type.ime())){
                 anim.translationY(0).start();
                 return insets;
             }
             if(!mDoPanning)
                 return insets;
-            int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
-            anim.translationY(-imeHeight).start();
+            anim.translationY(-insets.getInsets(WindowInsetsCompat.Type.ime()).bottom).start();
             mDoPanning = false;
             return insets;
         });

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -156,12 +156,12 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
             int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
             // Autopanning (if keyboardPan wasn't clicked)
             if(!mDoPanning) {
-                int cursorY = minecraftGLView.touchLastY;
+                int cursorY = (int) (GLFW.cursorY * minecraftGLView.mSurface.getHeight());
                 int visibleHeight = minecraftGLView.mSurface.getHeight() - imeHeight;
                 if(cursorY < visibleHeight)
                     return insets;
                 final int padding = 50;
-                int translationY = cursorY - visibleHeight + padding;
+                int translationY = Math.min(imeHeight, cursorY - visibleHeight + padding);
                 anim.translationY(-translationY).start();
                 return insets;
             }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -104,7 +104,8 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
     private GameService.LocalBinder mServiceBinder;
 
     private QuickSettingSideDialog mQuickSettingSideDialog;
-    private static boolean mDoPanning = false;
+
+    public static boolean mDoPanning = false;
     public static int mImeHeight = 0;
 
     @Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -147,12 +147,13 @@ public class MinecraftGLSurface extends View implements GrabListener, GamepadEna
         boolean ret = mCurrentTouchProcessor.processTouchEvent(e);
         if(MainActivity.mImeHeight > 0){
             int translationY = Tools.getTranslationFromCursorY(
-                    (int)(GLFW.cursorY * mSurface.getHeight()),
+                    (int)(GLFW.cursorY * mSurface.getHeight() + 100),
                     mSurface.getHeight(),
                     MainActivity.mImeHeight,
                     50
             );
             mSurface.setTranslationY(-translationY);
+            ((MainActivity) getContext()).cursor.setTranslationY(-translationY);
         }
         return ret;
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -150,7 +150,7 @@ public class MinecraftGLSurface extends View implements GrabListener, GamepadEna
                     (int)(GLFW.cursorY * mSurface.getHeight() + 100),
                     mSurface.getHeight(),
                     MainActivity.mImeHeight,
-                    50
+                    0
             );
             mSurface.setTranslationY(-translationY);
             mTouchpad.setTranslationY(-translationY);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -83,9 +83,6 @@ public class MinecraftGLSurface extends View implements GrabListener, GamepadEna
     private View mTouchpad;
     private boolean mLastGrabState = false;
 
-    public int touchLastX;
-    public int touchLastY;
-
     public MinecraftGLSurface(Context context) {
         this(context, null);
     }
@@ -147,8 +144,6 @@ public class MinecraftGLSurface extends View implements GrabListener, GamepadEna
             return true; //mouse event handled successfully
         }
         if (mIngameProcessor == null || mInGUIProcessor == null) return true;
-        touchLastX = (int)e.getX();
-        touchLastY = (int)e.getY();
         return mCurrentTouchProcessor.processTouchEvent(e);
     }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -79,9 +79,12 @@ public class MinecraftGLSurface extends View implements GrabListener, GamepadEna
     private final InGameEventProcessor mIngameProcessor = new InGameEventProcessor(this, mSensitivityFactor);
     private final InGUIEventProcessor mInGUIProcessor = new InGUIEventProcessor(this);
     private TouchEventProcessor mCurrentTouchProcessor = mInGUIProcessor;
-    private AndroidPointerCapture mPointerCapture;
+    public AndroidPointerCapture mPointerCapture;
     private View mTouchpad;
     private boolean mLastGrabState = false;
+
+    public int touchLastX;
+    public int touchLastY;
 
     public MinecraftGLSurface(Context context) {
         this(context, null);
@@ -144,6 +147,8 @@ public class MinecraftGLSurface extends View implements GrabListener, GamepadEna
             return true; //mouse event handled successfully
         }
         if (mIngameProcessor == null || mInGUIProcessor == null) return true;
+        touchLastX = (int)e.getX();
+        touchLastY = (int)e.getY();
         return mCurrentTouchProcessor.processTouchEvent(e);
     }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -144,7 +144,17 @@ public class MinecraftGLSurface extends View implements GrabListener, GamepadEna
             return true; //mouse event handled successfully
         }
         if (mIngameProcessor == null || mInGUIProcessor == null) return true;
-        return mCurrentTouchProcessor.processTouchEvent(e);
+        boolean ret = mCurrentTouchProcessor.processTouchEvent(e);
+        if(MainActivity.mImeHeight > 0){
+            int translationY = Tools.getTranslationFromCursorY(
+                    (int)(GLFW.cursorY * mSurface.getHeight()),
+                    mSurface.getHeight(),
+                    MainActivity.mImeHeight,
+                    50
+            );
+            mSurface.setTranslationY(-translationY);
+        }
+        return ret;
     }
 
     private void createGamepad(InputDevice inputDevice) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -154,8 +154,16 @@ public class MinecraftGLSurface extends View implements GrabListener, GamepadEna
                     MainActivity.mImeHeight,
                     0
             );
-            mSurface.setTranslationY(-translationY);
-            mTouchpad.setTranslationY(-translationY);
+            // If the view was force panned (KeyboardPan keycode) apply an animation instead of immediate override
+            // This fixes weird jumps when the user moves the cursor first time after pressing that keycode
+            if(MainActivity.mDoPanning) {
+                mSurface.animate().setDuration(100).translationY(-translationY).start();
+                mTouchpad.animate().setDuration(100).translationY(-translationY).start();
+                MainActivity.mDoPanning = false;
+            } else {
+                mSurface.setTranslationY(-translationY);
+                mTouchpad.setTranslationY(-translationY);
+            }
         }
         return ret;
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -156,10 +156,10 @@ public class MinecraftGLSurface extends View implements GrabListener, GamepadEna
             );
             // If the view was force panned (KeyboardPan keycode) apply an animation instead of immediate override
             // This fixes weird jumps when the user moves the cursor first time after pressing that keycode
-            if(MainActivity.mDoPanning) {
+            if(MainActivity.mForceFullPanning) {
                 mSurface.animate().setDuration(100).translationY(-translationY).start();
                 mTouchpad.animate().setDuration(100).translationY(-translationY).start();
-                MainActivity.mDoPanning = false;
+                MainActivity.mForceFullPanning = false;
             } else {
                 mSurface.setTranslationY(-translationY);
                 mTouchpad.setTranslationY(-translationY);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -80,7 +80,7 @@ public class MinecraftGLSurface extends View implements GrabListener, GamepadEna
     private final InGameEventProcessor mIngameProcessor = new InGameEventProcessor(this, mSensitivityFactor);
     private final InGUIEventProcessor mInGUIProcessor = new InGUIEventProcessor(this);
     private TouchEventProcessor mCurrentTouchProcessor = mInGUIProcessor;
-    public AndroidPointerCapture mPointerCapture;
+    private AndroidPointerCapture mPointerCapture;
     private View mTouchpad;
     private boolean mLastGrabState = false;
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -153,7 +153,7 @@ public class MinecraftGLSurface extends View implements GrabListener, GamepadEna
                     50
             );
             mSurface.setTranslationY(-translationY);
-            ((MainActivity) getContext()).cursor.setTranslationY(-translationY);
+            mTouchpad.setTranslationY(-translationY);
         }
         return ret;
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -146,6 +146,7 @@ public class MinecraftGLSurface extends View implements GrabListener, GamepadEna
         }
         if (mIngameProcessor == null || mInGUIProcessor == null) return true;
         boolean ret = mCurrentTouchProcessor.processTouchEvent(e);
+        // Keep cursor on screen if panning with IME inset
         if(MainActivity.mImeHeight > 0){
             int translationY = Tools.getTranslationFromCursorY(
                     (int)(GLFW.cursorY * mSurface.getHeight() + 100),

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -147,7 +147,7 @@ public class MinecraftGLSurface extends View implements GrabListener, GamepadEna
         if (mIngameProcessor == null || mInGUIProcessor == null) return true;
         boolean ret = mCurrentTouchProcessor.processTouchEvent(e);
         // Keep cursor on screen if panning with IME inset
-        if(MainActivity.mImeHeight > 0){
+        if(LauncherPreferences.PREF_KEYBOARD_AUTOPANNING && MainActivity.mImeHeight > 0){
             int translationY = Tools.getTranslationFromCursorY(
                     (int)(GLFW.cursorY * mSurface.getHeight() + 100),
                     mSurface.getHeight(),

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -918,4 +918,11 @@ public final class Tools {
         waitOnObj();
         throw new RuntimeException();
     }
+
+    public static int getTranslationFromCursorY(int cursorY, int viewHeight, int imeHeight, int padding){
+        int visibleHeight = viewHeight - imeHeight;
+        if(cursorY < visibleHeight)
+            return 0;
+        return Math.min(imeHeight, cursorY - visibleHeight + padding);
+    }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
@@ -31,6 +31,7 @@ public class ControlData {
     public static final int SPECIALBTN_SCROLLUP = -7;
     public static final int SPECIALBTN_SCROLLDOWN = -8;
     public static final int SPECIALBTN_MENU = -9;
+    public static final int SPECIALBTN_KEYBOARDPAN = -10;
 
     private static ControlData[] SPECIAL_BUTTONS;
     private static List<String> SPECIAL_BUTTON_NAME_ARRAY;
@@ -166,7 +167,8 @@ public class ControlData {
                     new ControlData("MID", new int[]{SPECIALBTN_MOUSEMID}, "${margin}", "${margin}"),
                     new ControlData("SCROLLUP", new int[]{SPECIALBTN_SCROLLUP}, "${margin}", "${margin}"),
                     new ControlData("SCROLLDOWN", new int[]{SPECIALBTN_SCROLLDOWN}, "${margin}", "${margin}"),
-                    new ControlData("MENU", new int[]{SPECIALBTN_MENU}, "${margin}", "${margin}")
+                    new ControlData("MENU", new int[]{SPECIALBTN_MENU}, "${margin}", "${margin}"),
+                    new ControlData("KeyboardPan", new int[]{SPECIALBTN_KEYBOARDPAN}, "${margin}", "${margin}")
             };
         }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -223,7 +223,11 @@ public class ControlButton extends TextView implements ControlInterface {
     private void sendSpecialKey(int keycode, boolean isDown){
         switch (keycode) {
             case ControlData.SPECIALBTN_KEYBOARD:
-                if(isDown) MainActivity.switchKeyboardState();
+                if(isDown) MainActivity.switchKeyboardState(false);
+                break;
+
+            case ControlData.SPECIALBTN_KEYBOARDPAN:
+                if(isDown) MainActivity.switchKeyboardState(true);
                 break;
 
             case ControlData.SPECIALBTN_TOGGLECTRL:

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -72,6 +72,7 @@ public class LauncherPreferences {
     public static boolean PREF_VERIFY_FILES = true;
 
     public static boolean PREF_FREEDRENO_SYSMEM = false;
+    public static boolean PREF_KEYBOARD_AUTOPANNING = true;
 
 
     public static void loadPreferences(Context ctx) {
@@ -116,6 +117,7 @@ public class LauncherPreferences {
         PREF_VERIFY_FILES = DEFAULT_PREF.getBoolean("checkGameFiles", true);
         PREF_RAPID_START = DEFAULT_PREF.getBoolean("fastStartupCheck", true);
         PREF_FREEDRENO_SYSMEM = DEFAULT_PREF.getBoolean("freedrenoSysmem", false);
+        PREF_KEYBOARD_AUTOPANNING = DEFAULT_PREF.getBoolean("keyboardAutoPanning", true);
 
         String argLwjglLibname = "-Dorg.lwjgl.opengl.libname=";
         for (String arg : JREUtils.parseJavaArguments(PREF_CUSTOM_JAVA_ARGS)) {

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -440,4 +440,7 @@
     <string name="preference_sysmem_summary">Принуждает Turnip/Freedreno отрисовывать графику только в системную память. Включите, если игра работает медленно или вы наблюдаете проблемы отрисовки.</string>
     <string name="preference_microphone_access_title">Запросить доступ к микрофону</string>
     <string name="preference_microphone_access_description">Запрашивает у системы доступ к микрофону устройства в игре</string>
+    <string name="preference_category_keyboard">Настройки клавиатуры</string>
+    <string name="preference_keyboard_autopan_title">Разрешить перемещение окна клавиатурой</string>
+    <string name="preference_keyboard_autopan_summary">Разрешает экранной клавиатуре перемещать окно игры, а не перекрывать его, если последнее касание было в зоне появления клавиатуры. Не влияет на явный вызов с перемещением в раскладках.</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -488,4 +488,7 @@
     <string name="import_local_modpack">Import local modpack</string>
     <string name="preference_sysmem_title">Force rendering into the system memory</string>
     <string name="preference_sysmem_summary">Forces Freedreno to render directly into the system memory. Enable if performance is low or you experience rendering issues</string>
+    <string name="preference_category_keyboard">Keyboard settings</string>
+    <string name="preference_keyboard_autopan_title">Enable keyboard panning</string>
+    <string name="preference_keyboard_autopan_summary">Allows on-screen keyboard to move the game window instead of overlapping it if the last touch was below the visible zone. Has no effect on custom control layout buttons with the same function</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/xml/pref_control.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_control.xml
@@ -166,6 +166,14 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/preference_category_keyboard">
+        <SwitchPreference
+            android:key="keyboardAutoPanning"
+            android:title="@string/preference_keyboard_autopan_title"
+            android:summary="@string/preference_keyboard_autopan_summary"
+            />
+    </PreferenceCategory>
+
 
 
 


### PR DESCRIPTION
Implements keyboard panning i.e. makes the game window display on-top of the active on-screen keyboard instead of displaying below it.

Unsolved issues:
* ~~It works nice for the chat field, however, other input fields (like server address) are moved beyond screen space now.~~
* Untested on most devices ~~and older Android versions~~.