### PR TITLE
Fix[custom_controls]: improve error messaging on corrupt/empty layouts

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/LayoutBitmaps.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/LayoutBitmaps.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import org.apache.commons.io.IOUtils;
 
 import java.io.BufferedInputStream;
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -80,7 +81,7 @@ public class LayoutBitmaps {
             try {
                 ZipInputStream zipIn = new ZipInputStream(bufferedIn);
                 isZip = zipIn.getNextEntry() != null;
-            } catch (ZipException e) {
+            } catch (ZipException | EOFException e) {
                 isZip = false;
             } catch (IOException e) {
                 throw e;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/LayoutConverter.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/LayoutConverter.java
@@ -50,7 +50,7 @@ public class LayoutConverter {
             }
             return null;
         } catch (JSONException e) {
-            throw new JsonSyntaxException("Failed to load", e);
+            throw new JsonSyntaxException("Failed to load the layout. Maybe it's corrupted?", e);
         }
     }
 


### PR DESCRIPTION
Noticed this when got a corrupted (empty) `default.json` controlmap in my game directory.

EOFException is caught by IOException handler and then rethrown which causes a cryptic/empty "Error" message instead of explanation what occurred. Now it's handled properly.  
Also improved the invalid controlmap exception message.