### PR TITLE
Fix[cursor]: set cursor visible if requested

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -199,7 +199,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
 
             minecraftGLView.setSurfaceReadyListener(() -> {
                 try {
-                    if(!PREF_VIRTUAL_MOUSE_START) cursor.setVisibility(View.GONE);
+                    if(PREF_VIRTUAL_MOUSE_START) cursor.setVisibility(View.VISIBLE);
                     runCraft(version, classpath);
                 }catch (Throwable e){
                     Tools.showErrorRemote(e);


### PR DESCRIPTION
The cursor is hidden by default now which broke the virtual mouse start preference.

Closes: https://github.com/MojoLauncher/MojoLauncher/issues/447