### PR TITLE
Feat[forgelike_installer]: use LTW for Forgelike modloaders by default

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ForgelikeInstallFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ForgelikeInstallFragment.java
@@ -53,7 +53,7 @@ public abstract class ForgelikeInstallFragment extends ModVersionListFragment<Li
                 instance.installer = instanceInstaller;
                 // Switch the instance renderer to LTW to workaround early window brokeness on GL4ES
                 // Won't affect versions early than 1.17
-                if(LauncherPreferences.PREF_RENDERER.equals("opengles2")) instance.renderer = "opengles3_ltw";
+                if(instance.getLaunchRenderer().equals("opengles2")) instance.renderer = "opengles3_ltw";
             }, selectedVersion);
             ProgressLayout.clearProgress(ProgressLayout.INSTALL_MODPACK);
             instanceInstaller.start();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ForgelikeInstallFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ForgelikeInstallFragment.java
@@ -11,6 +11,7 @@ import net.kdt.pojavlaunch.instances.Instances;
 import net.kdt.pojavlaunch.modloaders.ForgelikeUtils;
 import net.kdt.pojavlaunch.modloaders.ForgelikeVersionListAdapter;
 import net.kdt.pojavlaunch.modloaders.ModloaderListenerProxy;
+import net.kdt.pojavlaunch.prefs.LauncherPreferences;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,6 +51,9 @@ public abstract class ForgelikeInstallFragment extends ModVersionListFragment<Li
                 instance.name = mUtils.getName();
                 instance.icon = mUtils.getIconName();
                 instance.installer = instanceInstaller;
+                // Switch the instance renderer to LTW to workaround early window brokeness on GL4ES
+                // Won't affect versions early than 1.17
+                if(LauncherPreferences.PREF_RENDERER.equals("opengles2")) instance.renderer = "opengles3_ltw";
             }, selectedVersion);
             ProgressLayout.clearProgress(ProgressLayout.INSTALL_MODPACK);
             instanceInstaller.start();


### PR DESCRIPTION
Fixes running Forge out-of-the-box on 1.17+. GL4ES does not support Forge's early window and the disablement flag does not work anymore.

Why not disable early window? Forge configuration explicitly mentions it may break some mods using newer GL. If we disable early window in the config, then user will have to modify this config even if they switched to LTW and other renderers with working early window.  
We can instead force LTW (if GL4ES is the default renderer) and thus everything will work correctly.  What if the device can't support LTW? Nothing will change, Forge is broken for them without modifying the config file same as now.