### PR TITLE
Feat[plugin]: add support for external natives plugin

### DIFF
--- a/app_pojavlauncher/src/main/AndroidManifest.xml
+++ b/app_pojavlauncher/src/main/AndroidManifest.xml
@@ -137,5 +137,6 @@
         <package android:name="git.mojo.ffmpeg"/>
         <package android:name="git.mojo.angle"/>
         <package android:name="git.mojo.zink"/>
+        <package android:name="git.mojo.natives"/>
     </queries>
 </manifest>

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/plugins/LibraryPlugin.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/plugins/LibraryPlugin.java
@@ -16,6 +16,7 @@ public class LibraryPlugin {
     public static final String ID_ANGLE_PLUGIN = "git.mojo.angle";
     public static final String ID_FFMPEG_PLUGIN = "git.mojo.ffmpeg";
     public static final String ID_ZINK_PLUGIN = "git.mojo.zink";
+    public static final String ID_NATIVES_PLUGIN = "git.mojo.natives";
 
     private String appId;
     private String libraryPath;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -283,7 +283,8 @@ public class JREUtils {
     public static native int chdir(String path);
 
     public static native void setLdLibraryPath(String ldLibraryPath);
-    public static native void setExtraNativeLibraryPath(String path);
+    // See the redirect hook on the JNI side
+    public static native void setRedirectLibraryPath(String path);
     public static native boolean configureRenderspec(String eglPath, boolean useLoaderBypass, boolean useGles, int glesVersion);
     public static native void configureRenderspecDisplay(int width, int height, int refreshRate);
     private static native void nsetRendererLibraryPath(String path);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -283,6 +283,7 @@ public class JREUtils {
     public static native int chdir(String path);
 
     public static native void setLdLibraryPath(String ldLibraryPath);
+    public static native void setExtraNativeLibraryPath(String path);
     public static native boolean configureRenderspec(String eglPath, boolean useLoaderBypass, boolean useGles, int glesVersion);
     public static native void configureRenderspecDisplay(int width, int height, int refreshRate);
     private static native void nsetRendererLibraryPath(String path);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
@@ -15,6 +15,7 @@ import net.kdt.pojavlaunch.instances.Instance;
 import net.kdt.pojavlaunch.lifecycle.LifecycleAwareAlertDialog;
 import net.kdt.pojavlaunch.multirt.MultiRTUtils;
 import net.kdt.pojavlaunch.multirt.Runtime;
+import net.kdt.pojavlaunch.plugins.LibraryPlugin;
 import net.kdt.pojavlaunch.prefs.LauncherPreferences;
 import net.kdt.pojavlaunch.utils.DateUtils;
 import net.kdt.pojavlaunch.utils.FileUtils;
@@ -237,11 +238,17 @@ public class GameRunner {
             javaArgList.add("-Dlog4j.configurationFile=" + configFile);
         }
 
+        // This allows some mods to use additional libs provided via plugin so we don't need to bloat our app with uncommon stuff
+        LibraryPlugin natives = LibraryPlugin.discoverPlugin(activity, LibraryPlugin.ID_NATIVES_PLUGIN);
+        String additionalNativesDir = natives != null ? (':' + natives.getLibraryPath()) : "";
+
         File versionSpecificNativesDir = new File(Tools.DIR_CACHE, "natives/"+versionId);
         if(versionSpecificNativesDir.exists()) {
             String dirPath = versionSpecificNativesDir.getAbsolutePath();
-            javaArgList.add("-Djava.library.path="+dirPath+":"+Tools.NATIVE_LIB_DIR);
+            javaArgList.add("-Djava.library.path="+dirPath+":"+Tools.NATIVE_LIB_DIR+additionalNativesDir);
             javaArgList.add("-Djna.boot.library.path="+dirPath);
+        } else {
+            javaArgList.add("-Djava.library.path="+Tools.NATIVE_LIB_DIR+additionalNativesDir);
         }
 
         File lwjglExtractDir = new File(Tools.DIR_CACHE, "lwjgl_native/"+versionId);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
@@ -239,9 +239,12 @@ public class GameRunner {
         }
 
         // This allows some mods to use additional libs provided via plugin so we don't need to bloat our app with uncommon stuff
-        LibraryPlugin natives = LibraryPlugin.discoverPlugin(activity, LibraryPlugin.ID_NATIVES_PLUGIN);
-        String additionalNativesDir = natives != null ? (':' + natives.getLibraryPath()) : "";
-        JREUtils.setExtraNativeLibraryPath(natives.getLibraryPath());
+        String additionalNativesDir;
+        LibraryPlugin natives;
+        if((natives = LibraryPlugin.discoverPlugin(activity, LibraryPlugin.ID_NATIVES_PLUGIN)) != null){
+            additionalNativesDir = natives.getLibraryPath();
+            JREUtils.setRedirectLibraryPath(additionalNativesDir);
+        } else additionalNativesDir = "";
 
         File versionSpecificNativesDir = new File(Tools.DIR_CACHE, "natives/"+versionId);
         if(versionSpecificNativesDir.exists()) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
@@ -241,6 +241,7 @@ public class GameRunner {
         // This allows some mods to use additional libs provided via plugin so we don't need to bloat our app with uncommon stuff
         LibraryPlugin natives = LibraryPlugin.discoverPlugin(activity, LibraryPlugin.ID_NATIVES_PLUGIN);
         String additionalNativesDir = natives != null ? (':' + natives.getLibraryPath()) : "";
+        JREUtils.setExtraNativeLibraryPath(natives.getLibraryPath());
 
         File versionSpecificNativesDir = new File(Tools.DIR_CACHE, "natives/"+versionId);
         if(versionSpecificNativesDir.exists()) {

--- a/app_pojavlauncher/src/main/jni/jre_launcher/native_library_hook.c
+++ b/app_pojavlauncher/src/main/jni/jre_launcher/native_library_hook.c
@@ -13,8 +13,14 @@
 
 #define TAG __FILE_NAME__
 #include <log.h>
+#include <libgen.h>
 
 extern bool apiRequiresHints();
+
+const char* additional_natives_dir = NULL;
+
+const char* replacements = "libimgui-moulberry92-java64.so";
+
 
 // Java 21 style hook
 typedef jboolean (*NativeLibraries_load)(JNIEnv *env, jclass cls, jobject lib, jstring name, jboolean isBuiltin, jboolean throwExceptionIfFail);
@@ -43,10 +49,29 @@ static void library_preload_hook(JNIEnv *env, const char* name) {
     }
 }
 
+static jstring library_override_hook(JNIEnv* env, jstring original_name, const char* name){
+    if(!additional_natives_dir) return original_name;
+    char* _name = strdup(name);
+    char* base = basename(_name);
+    if(strstr(replacements, base) == NULL) {
+        free(_name);
+        return original_name;
+    }
+    uint32_t buf_size = strlen(additional_natives_dir) + strlen(base) + 3;
+    char* buf = malloc(buf_size);
+    snprintf(buf, buf_size, "%s/%s", additional_natives_dir, base);
+    printf("Overriding library load: %s -> %s\n", name, buf);
+    jstring new = (*env)->NewStringUTF(env, buf);
+    free(_name);
+    free(buf);
+    return new;
+}
+
 #define NATIVES_HOOK(CALLTHROUGH, RESULT, RESULT_RETURN) \
 do { \
     const char *name_n = (*env)->GetStringUTFChars(env, name, NULL); \
     library_preload_hook(env, name_n); \
+    name = library_override_hook(env, name, name_n); \
     const bool hintsRequired = apiRequiresHints(); \
     hinter_t hinter; \
     if (hintsRequired) hinter_process(&hinter, name_n); \
@@ -118,4 +143,12 @@ bool installClassLoaderHooks(JNIEnv *env, JNIEnv* vm_env) {
     err:
     throwException(env, STAGE_FIND_HOOKS, JNI_ERR, "Cannot find hook target.");
     return false;
+}
+
+JNIEXPORT void JNICALL
+Java_net_kdt_pojavlaunch_utils_JREUtils_setExtraNativeLibraryPath(JNIEnv *env, jclass clazz,
+                                                                  jstring path) {
+    const char* _path = (*env)->GetStringUTFChars(env, path, NULL);
+    additional_natives_dir = strdup(_path);
+    (*env)->ReleaseStringUTFChars(env, path, _path);
 }

--- a/app_pojavlauncher/src/main/jni/jre_launcher/native_library_hook.c
+++ b/app_pojavlauncher/src/main/jni/jre_launcher/native_library_hook.c
@@ -17,6 +17,7 @@
 
 extern bool apiRequiresHints();
 
+#define NATIVEDIR_BUF_SIZE 1024
 const char* additional_natives_dir = NULL;
 
 const char* replacements = "libimgui-moulberry92-java64.so";
@@ -49,21 +50,17 @@ static void library_preload_hook(JNIEnv *env, const char* name) {
     }
 }
 
-static jstring library_override_hook(JNIEnv* env, jstring original_name, const char* name){
+// Redirects known libraries load path to predefined one
+static jstring library_redirect_hook(JNIEnv* env, jstring original_name, const char* name){
     if(!additional_natives_dir) return original_name;
-    char* _name = strdup(name);
-    char* base = basename(_name);
+    char* base = basename(name);
     if(strstr(replacements, base) == NULL) {
-        free(_name);
         return original_name;
     }
-    uint32_t buf_size = strlen(additional_natives_dir) + strlen(base) + 3;
-    char* buf = malloc(buf_size);
-    snprintf(buf, buf_size, "%s/%s", additional_natives_dir, base);
-    printf("Overriding library load: %s -> %s\n", name, buf);
+    char buf[NATIVEDIR_BUF_SIZE];
+    snprintf(buf, NATIVEDIR_BUF_SIZE, "%s/%s", additional_natives_dir, base);
+    printf("Redirecting library load: %s -> %s\n", name, buf);
     jstring new = (*env)->NewStringUTF(env, buf);
-    free(_name);
-    free(buf);
     return new;
 }
 
@@ -71,7 +68,7 @@ static jstring library_override_hook(JNIEnv* env, jstring original_name, const c
 do { \
     const char *name_n = (*env)->GetStringUTFChars(env, name, NULL); \
     library_preload_hook(env, name_n); \
-    name = library_override_hook(env, name, name_n); \
+    name = library_redirect_hook(env, name, name_n); \
     const bool hintsRequired = apiRequiresHints(); \
     hinter_t hinter; \
     if (hintsRequired) hinter_process(&hinter, name_n); \
@@ -146,7 +143,7 @@ bool installClassLoaderHooks(JNIEnv *env, JNIEnv* vm_env) {
 }
 
 JNIEXPORT void JNICALL
-Java_net_kdt_pojavlaunch_utils_JREUtils_setExtraNativeLibraryPath(JNIEnv *env, jclass clazz,
+Java_net_kdt_pojavlaunch_utils_JREUtils_setRedirectLibraryPath(JNIEnv *env, jclass clazz,
                                                                   jstring path) {
     const char* _path = (*env)->GetStringUTFChars(env, path, NULL);
     additional_natives_dir = strdup(_path);


### PR DESCRIPTION
This allows Mojo to load additional native libraries from the plugin which can be updated separately. This then allows us to provide support for mods using native libraries without bloating the main app.

Examples are: VulkanMod (won't be needed on 26.2+), DistantHorizons, voxy, Axiom