### PR TITLE
Feat[env]: ignore program linking errors on LTW

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -111,6 +111,9 @@ public class JREUtils {
         // Fix white color on banner and sheep, since GL4ES 1.1.5
         envMap.put("LIBGL_NORMALIZE", "1");
 
+        // Fix new snapshots failing to run on almost all devices
+        envMap.put("LTW_IGNORE_LINK_ERRORS", "1");
+
         if(PREF_DUMP_SHADERS)
             envMap.put("LIBGL_VGPU_DUMP", "1");
         if(PREF_VSYNC_IN_ZINK)


### PR DESCRIPTION
Fixes running 26.3-snapshot2+