### PR TITLE
Delete crowdin.yml

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,0 @@
-files:
-  - source: /app_pojavlauncher/src/main/res/values/strings.xml
-    translation: /app_pojavlauncher/src/main/res/values-%android_code%/%original_file_name%


### PR DESCRIPTION
Keeping crowdin.yml is unnecessary since we’re currently using vibe-translate instead:
https://github.com/MojoLauncher/vibe-translate⁠