### PR TITLE
Feat[activity]: restart launcher activity on game exit

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/ExitActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/ExitActivity.java
@@ -41,8 +41,8 @@ public class ExitActivity extends AppCompatActivity {
 
     @SuppressWarnings("unused") //used by native jre_launcher_new
     public static void showExitMessage(Context ctx, int code, boolean isSignal) {
-        if((!isSignal && code == 0) || ctx == null) {
-            Tools.restartLauncherActivity(ctx);
+        if((!isSignal && code == 0)) {
+            if(ctx != null) Tools.restartLauncherActivity(ctx);
             System.exit(0);
             return;
         }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/ExitActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/ExitActivity.java
@@ -42,6 +42,7 @@ public class ExitActivity extends AppCompatActivity {
     @SuppressWarnings("unused") //used by native jre_launcher_new
     public static void showExitMessage(Context ctx, int code, boolean isSignal) {
         if((!isSignal && code == 0) || ctx == null) {
+            Tools.restartLauncherActivity(ctx);
             System.exit(0);
             return;
         }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -915,6 +915,7 @@ public final class Tools {
                 .setNegativeButton(android.R.string.cancel, null)
                 .setPositiveButton(android.R.string.ok, (p1, p2) -> {
                     try {
+                        Tools.restartLauncherActivity(ctx);
                         Tools.fullyExit();
                     } catch (Throwable th) {
                         Log.w(Tools.APP_NAME, "Could not enable System.exit() method!", th);
@@ -948,5 +949,11 @@ public final class Tools {
         if(cursorY < visibleHeight)
             return 0;
         return Math.min(imeHeight, cursorY - visibleHeight + padding);
+    }
+
+    public static void restartLauncherActivity(Context context){
+        Intent intent = new Intent(context, LauncherActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        context.getApplicationContext().startActivity(intent);
     }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import net.kdt.pojavlaunch.Architecture;
 import net.kdt.pojavlaunch.JVersionList;
+import net.kdt.pojavlaunch.LauncherActivity;
 import net.kdt.pojavlaunch.Tools;
 import net.kdt.pojavlaunch.authenticator.accounts.Account;
 import net.kdt.pojavlaunch.instances.Instance;
@@ -286,6 +287,7 @@ public class GameRunner {
             }
         }
 
+        Tools.restartLauncherActivity(activity);
         Tools.fullyExit();
     }
 


### PR DESCRIPTION
This makes the launcher go back to the main UI after the game exits thus improving UX - user is returned into launcher with a nice animation instead of crashing into desktop (on my device it doesn't even have an animation).

The activity is restarted in three places:
* On force exit (quick settings dialog)
* On safe game exit in GameRunner
* In ExitActivity when JVM shutdowns with exit code 0

Game crashes still show a dialog and fully exit, not sure if it needs a restart too.