### PR TITLE
Fix[glinfo]: relax vendor checks for ANGLE-only devices

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/GLInfoUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/GLInfoUtils.java
@@ -171,7 +171,7 @@ public class GLInfoUtils {
          * @return
          */
         public boolean isAdreno() {
-            return renderer.contains("Adreno") && vendor.equals("Qualcomm");
+            return renderer.contains("Adreno") && vendor.contains("Qualcomm");
         }
 
         /**
@@ -179,7 +179,7 @@ public class GLInfoUtils {
          * @return
          */
         public boolean isAdreno500Lower(){
-            return vendor.equals("Qualcomm") &&
+            return vendor.contains("Qualcomm") &&
                     (renderer.contains("Adreno (TM) 5") ||
                     renderer.contains("Adreno (TM) 4") ||
                     renderer.contains("Adreno (TM) 3") ||


### PR DESCRIPTION
On modern A17/A18+ devices ANGLE will be used by default hence breaking our GPU detection heuristics. With this commit less strict comparison is used so we can detect vendor even with ANGLE active.

With ANGLE vendor string is "Google (%vendor%)"