### PR TITLE
Feat[prefs]: add manual JVM memory input dialog

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/MemoryInputDialog.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/MemoryInputDialog.java
@@ -1,0 +1,45 @@
+package net.kdt.pojavlaunch.prefs;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.EditText;
+
+import androidx.appcompat.app.AlertDialog;
+
+import git.artdeell.mojo.R;
+
+public class MemoryInputDialog {
+    public interface Callback {
+        void setMemory(int value);
+    }
+    private final AlertDialog mDialog;
+    private final View mInputView;
+    private final EditText mEditField;
+    public MemoryInputDialog(Context context, Callback onMemorySet){
+        mInputView = LayoutInflater.from(context).inflate(R.layout.dialog_mem_input, null, false);
+        mEditField = mInputView.findViewById(R.id.mem_input_field);
+        mDialog = new AlertDialog.Builder(context)
+                .setView(mInputView)
+                .setTitle(R.string.dialog_mem_alloc_title)
+                .setMessage(R.string.dialog_mem_alloc_message)
+                .setPositiveButton(android.R.string.ok, (l,p ) -> onMemorySet.setMemory(this.getMemory()))
+                .setOnDismissListener(dialog -> {})
+                .setNegativeButton(android.R.string.cancel, (dialog, which) -> {})
+                .create();
+    }
+    public void show(){
+        mDialog.show();
+    }
+    private int getMemory(){
+        String text = mEditField.getText().toString();
+        mEditField.setText(null);
+        int value;
+        try {
+            value = Integer.parseInt(text);
+        } catch (NumberFormatException e) {
+            value = 0;
+        }
+        return value;
+    }
+}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceJavaFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceJavaFragment.java
@@ -15,9 +15,11 @@ import net.kdt.pojavlaunch.contracts.OpenDocumentWithExtension;
 import net.kdt.pojavlaunch.multirt.MultiRTConfigDialog;
 import net.kdt.pojavlaunch.prefs.CustomSeekBarPreference;
 import net.kdt.pojavlaunch.prefs.LauncherPreferences;
+import net.kdt.pojavlaunch.prefs.MemoryInputDialog;
 
 public class LauncherPreferenceJavaFragment extends LauncherPreferenceFragment {
     private MultiRTConfigDialog mDialogScreen;
+    private MemoryInputDialog mInputDialog;
     private final ActivityResultLauncher<Object> mVmInstallLauncher =
             registerForActivityResult(new OpenDocumentWithExtension("xz"), (data)->{
                 if(data != null) Tools.installRuntimeFromUri(getContext(), data);
@@ -42,6 +44,11 @@ public class LauncherPreferenceJavaFragment extends LauncherPreferenceFragment {
         memorySeekbar.setValue(ramAllocation);
         memorySeekbar.setSuffix(" MB");
 
+        memorySeekbar.setOnPreferenceClickListener(pref -> {
+            this.openMemoryInput(memorySeekbar::setValue);
+            return true;
+        });
+
         EditTextPreference editJVMArgs = findPreference("javaArgs");
         if (editJVMArgs != null) {
             editJVMArgs.setOnBindEditTextListener(TextView::setSingleLine);
@@ -59,5 +66,11 @@ public class LauncherPreferenceJavaFragment extends LauncherPreferenceFragment {
             mDialogScreen.prepare(getContext(), mVmInstallLauncher);
         }
         mDialogScreen.show();
+    }
+
+    private void openMemoryInput(MemoryInputDialog.Callback onMemSet){
+        if(mInputDialog == null)
+            mInputDialog = new MemoryInputDialog(this.getContext(), onMemSet);
+        mInputDialog.show();
     }
 }

--- a/app_pojavlauncher/src/main/res/layout/dialog_mem_input.xml
+++ b/app_pojavlauncher/src/main/res/layout/dialog_mem_input.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+    <EditText
+        android:id="@+id/mem_input_field"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:inputType="numberDecimal"
+        android:layout_marginRight="12dp"
+        android:layout_marginLeft="12dp"
+        android:hint="@string/dialog_mem_alloc_hint"
+        />
+</LinearLayout>

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -440,4 +440,7 @@
     <string name="migration_progress_space">На вашем устройстве недостаточно места для переноса данных. Освободите как минимум $%1l МБ или больше чтобы продолжить</string>
     <string name="preference_alsoft_opensl_title">Принудительно использовать OpenSL для аудио</string>
     <string name="preference_alsoft_opensl_summary">Включает принудительное использование OpenSL вместо Oboe для ALSoft. Может исправить проблемы с записью звука на некоторых устройствах. Выключите если вы наблюдаете проблемы с записью или воспроизведением звука.</string>
+    <string name="dialog_mem_alloc_title">Выделение памяти</string>
+    <string name="dialog_mem_alloc_message">Введите необходимое кол-во памяти в мегабайтах</string>
+    <string name="dialog_mem_alloc_hint">1024</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -505,4 +505,7 @@
     <string name="migration_notice">Looks like you have already used this application in the past. You can import old launcher installation data from miscellaneous settings.</string>
     <string name="preference_alsoft_opensl_title">Forcefully use OpenSL for audio</string>
     <string name="preference_alsoft_opensl_summary">Forcefully enables OpenSL backend in ALSoft instead of Oboe. Can fix audio capture issues on some devices. Disable if you see audio playback/capture issues</string>
+    <string name="dialog_mem_alloc_title">Memory allocation</string>
+    <string name="dialog_mem_alloc_message">Type required memory amount in megabytes.</string>
+    <string name="dialog_mem_alloc_hint">e.g. 1024</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/xml/pref_java.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_java.xml
@@ -28,7 +28,7 @@
             app2:showSeekBarValue="true"
             app2:min="@integer/memory_seekbar_min"
             app2:seekBarIncrement="@integer/memory_seekbar_increment"
-            app2:selectable="false"/>
+            app2:selectable="true"/>
 
         <SwitchPreference
             android:defaultValue="true"


### PR DESCRIPTION
Adds a dialog to manually input required memory amount for JVM. The seekbar still works as it did before, just the preference itself can be clicked now to open the dialog.

Seems to work fine.

Working with XMLs is so fun.