### PR TITLE
Add exact value entry for sliders

### DIFF
--- a/app_pojavlauncher/src/main/java/com/kdt/CustomSeekbar.java
+++ b/app_pojavlauncher/src/main/java/com/kdt/CustomSeekbar.java
@@ -87,6 +87,14 @@ public class CustomSeekbar extends SeekBar {
         mIncrement = increment;
     }
 
+    public int getCustomMin() {
+        return mMin;
+    }
+
+    public int getCustomMax() {
+        return super.getMax() + mMin;
+    }
+
     public void setRange(int min, int max) {
         mMin = min;
         setMax(max - min);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/CustomSeekBarPreference.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/CustomSeekBarPreference.java
@@ -4,9 +4,11 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Color;
+import android.text.InputType;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.SeekBar;
+import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -65,6 +67,7 @@ public class CustomSeekBarPreference extends SeekBarPreference {
 
         mTextView = (TextView) view.findViewById(R.id.seekbar_value);
         mTextView.setTextAlignment(View.TEXT_ALIGNMENT_TEXT_START);
+        mTextView.setOnClickListener(v -> openExactValueDialog());
         SeekBar seekBar = (SeekBar) view.findViewById(R.id.seekbar);
 
         seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
@@ -99,6 +102,32 @@ public class CustomSeekBarPreference extends SeekBarPreference {
         updateTextViewWithSuffix();
     }
 
+    private void openExactValueDialog() {
+        if(mTextView == null) return;
+        Context context = mTextView.getContext();
+        EditText input = new EditText(context);
+        input.setSingleLine();
+        input.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED);
+        input.setText(String.valueOf(getValue()));
+        input.setSelection(input.getText().length());
+
+        new androidx.appcompat.app.AlertDialog.Builder(context)
+                .setTitle(getTitle())
+                .setMessage(context.getString(R.string.slider_exact_value_prompt, getMin(), getMax()))
+                .setView(input)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                    try {
+                        int value = Integer.parseInt(input.getText().toString().trim());
+                        setValue(clampToRange(value));
+                        updateTextViewWithSuffix();
+                    } catch (NumberFormatException ignored) {
+                        // Ignore invalid edits and keep the current value.
+                    }
+                })
+                .show();
+    }
+
     /**
      * Set a suffix to be appended on the TextView associated to the value
      * @param suffix The suffix to append as a String
@@ -120,6 +149,10 @@ public class CustomSeekBarPreference extends SeekBarPreference {
     public void setMaxKeepIncrement(int max) {
         super.setMax(max);
         setSeekBarIncrement(mIncrement);
+    }
+
+    private int clampToRange(int value) {
+        return Math.max(getMin(), Math.min(getMax(), value));
     }
 
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/CustomSeekBarPreference.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/CustomSeekBarPreference.java
@@ -7,11 +7,12 @@ import android.graphics.Color;
 import android.text.InputType;
 import android.util.AttributeSet;
 import android.view.View;
-import android.widget.SeekBar;
 import android.widget.EditText;
+import android.widget.SeekBar;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.preference.PreferenceViewHolder;
 import androidx.preference.SeekBarPreference;
 
@@ -111,21 +112,24 @@ public class CustomSeekBarPreference extends SeekBarPreference {
         input.setText(String.valueOf(getValue()));
         input.setSelection(input.getText().length());
 
-        new androidx.appcompat.app.AlertDialog.Builder(context)
+        AlertDialog dialog = new AlertDialog.Builder(context)
                 .setTitle(getTitle())
                 .setMessage(context.getString(R.string.slider_exact_value_prompt, getMin(), getMax()))
                 .setView(input)
                 .setNegativeButton(android.R.string.cancel, null)
-                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
-                    try {
-                        int value = Integer.parseInt(input.getText().toString().trim());
-                        setValue(clampToRange(value));
-                        updateTextViewWithSuffix();
-                    } catch (NumberFormatException ignored) {
-                        // Ignore invalid edits and keep the current value.
-                    }
-                })
-                .show();
+                .setPositiveButton(android.R.string.ok, null)
+                .create();
+        dialog.setOnShowListener(d -> dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(v -> {
+            try {
+                int value = Integer.parseInt(input.getText().toString().trim());
+                setValue(clampToRange(value));
+                updateTextViewWithSuffix();
+                dialog.dismiss();
+            } catch (NumberFormatException ignored) {
+                input.setError(context.getString(R.string.slider_exact_value_invalid));
+            }
+        }));
+        dialog.show();
     }
 
     /**

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
@@ -19,6 +19,8 @@ import android.widget.EditText;
 import android.widget.Switch;
 import android.widget.TextView;
 
+import androidx.appcompat.app.AlertDialog;
+
 import com.kdt.CustomSeekbar;
 
 import git.artdeell.mojo.R;
@@ -186,25 +188,32 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         input.setText(String.valueOf(bar.getProgress()));
         input.setSelection(input.getText().length());
 
-        new androidx.appcompat.app.AlertDialog.Builder(context)
+        AlertDialog dialog = new AlertDialog.Builder(context)
                 .setTitle(label.getText())
                 .setMessage(context.getString(R.string.slider_exact_value_prompt, bar.getCustomMin(), bar.getCustomMax()))
                 .setView(input)
                 .setNegativeButton(android.R.string.cancel, null)
-                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
-                    try {
-                        int value = Integer.parseInt(input.getText().toString().trim());
-                        value = Math.max(bar.getCustomMin(), Math.min(bar.getCustomMax(), value));
-                        bar.setProgress(value);
-                        if (percentValue) {
-                            setSeekTextPercent(label, value);
-                        } else {
-                            setSeekTextMillisecond(label, value);
-                        }
-                    } catch (NumberFormatException ignored) {
-                    }
-                })
-                .show();
+                .setPositiveButton(android.R.string.ok, null)
+                .create();
+        dialog.setOnShowListener(d -> dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(v -> {
+            try {
+                int value = Integer.parseInt(input.getText().toString().trim());
+                if (value < bar.getCustomMin() || value > bar.getCustomMax()) {
+                    input.setError(context.getString(R.string.slider_exact_value_invalid));
+                    return;
+                }
+                bar.setProgress(value);
+                if (percentValue) {
+                    setSeekTextPercent(label, value);
+                } else {
+                    setSeekTextMillisecond(label, value);
+                }
+                dialog.dismiss();
+            } catch (NumberFormatException ignored) {
+                input.setError(context.getString(R.string.slider_exact_value_invalid));
+            }
+        }));
+        dialog.show();
     }
 
     private void updateGyroVisibility(boolean isEnabled) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
@@ -12,8 +12,10 @@ import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_SCALE_FACTOR;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.text.InputType;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
 import android.widget.Switch;
 import android.widget.TextView;
 
@@ -127,6 +129,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
             mEditor.putInt("gyroSensitivity", progress);
             setSeekTextPercent(mGyroSensitivityText, progress);
         });
+        mGyroSensitivityText.setOnClickListener(v -> editExactSeekValue(mGyroSensitivityBar, mGyroSensitivityText, true));
         mGyroSensitivityBar.setProgress((int) (mOriginalGyroSensitivity * 100f));
         setSeekTextPercent(mGyroSensitivityText, mGyroSensitivityBar.getProgress());
 
@@ -135,6 +138,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
             mEditor.putInt("mousespeed", progress);
             setSeekTextPercent(mMouseSpeedText, progress);
         });
+        mMouseSpeedText.setOnClickListener(v -> editExactSeekValue(mMouseSpeedBar, mMouseSpeedText, true));
         mMouseSpeedBar.setProgress((int) (mOriginalMouseSpeed * 100f));
         setSeekTextPercent(mMouseSpeedText, mMouseSpeedBar.getProgress());
 
@@ -143,6 +147,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
             mEditor.putInt("timeLongPressTrigger", progress);
             setSeekTextMillisecond(mGestureDelayText, progress);
         });
+        mGestureDelayText.setOnClickListener(v -> editExactSeekValue(mGestureDelayBar, mGestureDelayText, false));
         mGestureDelayBar.setProgress(mOriginalGestureDelay);
         setSeekTextMillisecond(mGestureDelayText, mGestureDelayBar.getProgress());
 
@@ -152,6 +157,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
             setSeekTextPercent(mResolutionText, progress);
             onResolutionChanged();
         });
+        mResolutionText.setOnClickListener(v -> editExactSeekValue(mResolutionBar, mResolutionText, true));
         mResolutionBar.setProgress((int) (mOriginalResolution * 100));
         setSeekTextPercent(mResolutionText, mResolutionBar.getProgress());
 
@@ -170,6 +176,35 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
 
     private static void setSeekText(TextView target, int format, int value) {
         target.setText(target.getContext().getString(format, value));
+    }
+
+    private void editExactSeekValue(CustomSeekbar bar, TextView label, boolean percentValue) {
+        Context context = label.getContext();
+        EditText input = new EditText(context);
+        input.setSingleLine();
+        input.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED);
+        input.setText(String.valueOf(bar.getProgress()));
+        input.setSelection(input.getText().length());
+
+        new androidx.appcompat.app.AlertDialog.Builder(context)
+                .setTitle(label.getText())
+                .setMessage(context.getString(R.string.slider_exact_value_prompt, bar.getCustomMin(), bar.getCustomMax()))
+                .setView(input)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                    try {
+                        int value = Integer.parseInt(input.getText().toString().trim());
+                        value = Math.max(bar.getCustomMin(), Math.min(bar.getCustomMax(), value));
+                        bar.setProgress(value);
+                        if (percentValue) {
+                            setSeekTextPercent(label, value);
+                        } else {
+                            setSeekTextMillisecond(label, value);
+                        }
+                    } catch (NumberFormatException ignored) {
+                    }
+                })
+                .show();
     }
 
     private void updateGyroVisibility(boolean isEnabled) {

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
     <string name="global_retry">Retry</string>
     <string name="global_default">Default</string>
     <string name="slider_exact_value_prompt">Enter a value from %1$d to %2$d</string>
+    <string name="slider_exact_value_invalid">Enter a whole number within the allowed range</string>
 
     <!-- MainActivity: strings -->
     <string name="mcn_exit_title">Application/Game exited with code %d, check latestlog.txt for more details.</string>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="global_select">Select</string>
     <string name="global_retry">Retry</string>
     <string name="global_default">Default</string>
+    <string name="slider_exact_value_prompt">Enter a value from %1$d to %2$d</string>
 
     <!-- MainActivity: strings -->
     <string name="mcn_exit_title">Application/Game exited with code %d, check latestlog.txt for more details.</string>


### PR DESCRIPTION
Clicking any value next to a Slider now opens a text field to input an exact value
Behavior:

Valid number in range: Set exactly
Valid below range: Clamp to minimum
Valid above range: Clamp to maximum
Empty: No change
Too large for `int`: No change
Cancel: No change