### PR TITLE
fix: don't crash when MainActivity is recreated without intent extras

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -68,7 +68,6 @@ import net.kdt.pojavlaunch.utils.jre.GameRunner;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.util.Objects;
 
 import git.artdeell.dnbootstrap.glfw.AndroidClipboardProvider;
 import git.artdeell.dnbootstrap.glfw.GLFW;
@@ -226,7 +225,12 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
 
             touchCharInput.setCharacterSender(new LwjglCharSender());
 
-            Bundle extras = Objects.requireNonNull(getIntent().getExtras());
+            Bundle extras = getIntent().getExtras();
+            if(extras == null) {
+                // Recreated after the process was killed in-game; nothing to restore.
+                finish();
+                return;
+            }
             String version = extras.getString(INTENT_LAUNCH_VERSION);
             File[] classpath = (File[]) extras.getSerializable(INTENT_LAUNCH_CLASSPATH);
 


### PR DESCRIPTION
When the process is killed while in-game, Android may recreate MainActivity without the launch intent extras. Objects.requireNonNull() then threw a NullPointerException on startup.

Fixes #545