### PR TITLE
fix: bounds check when merging inherited game arguments

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -68,7 +68,6 @@ import net.kdt.pojavlaunch.utils.jre.GameRunner;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.util.Objects;
 
 import git.artdeell.dnbootstrap.glfw.AndroidClipboardProvider;
 import git.artdeell.dnbootstrap.glfw.GLFW;
@@ -226,7 +225,12 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
 
             touchCharInput.setCharacterSender(new LwjglCharSender());
 
-            Bundle extras = Objects.requireNonNull(getIntent().getExtras());
+            Bundle extras = getIntent().getExtras();
+            if(extras == null) {
+                // Recreated after the process was killed in-game; nothing to restore.
+                finish();
+                return;
+            }
             String version = extras.getString(INTENT_LAUNCH_VERSION);
             File[] classpath = (File[]) extras.getSerializable(INTENT_LAUNCH_CLASSPATH);
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -637,6 +637,10 @@ public final class Tools {
                             String perCustomArgStr = (String) perCustomArg;
                             // Check if there is a duplicate argument on combine
                             if (perCustomArgStr.startsWith("--") && totalArgList.contains(perCustomArgStr)) {
+                                // If the flag is the last argument there is no value to merge
+                                if(i + 1 >= customVer.arguments.game.length) {
+                                    continue;
+                                }
                                 perCustomArg = customVer.arguments.game[i + 1];
                                 if (perCustomArg instanceof String) {
                                     perCustomArgStr = (String) perCustomArg;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/AndroidPointerCapture.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/AndroidPointerCapture.java
@@ -84,6 +84,13 @@ public class AndroidPointerCapture implements ViewTreeObserver.OnWindowFocusChan
             // The relative position will already be written down into the mVector variable.
         }
 
+        // Some OEM touchpads report the axes swapped. Mouse input is relative, so leave it alone.
+        if(LauncherPreferences.PREF_SWAP_TOUCHPAD_AXES && (event.getSource() & InputDevice.SOURCE_CLASS_TRACKBALL) == 0) {
+            float tmp = mVector[0];
+            mVector[0] = mVector[1];
+            mVector[1] = tmp;
+        }
+
         // Avoid going through the JNI each time.
         if(!GLFW.isGrabbing()) {
             enableTouchpadIfNecessary();
@@ -111,8 +118,12 @@ public class AndroidPointerCapture implements ViewTreeObserver.OnWindowFocusChan
                 return LauncherGLSurface.sendMouseButtonUnconverted(event.getActionButton(), false);
             case MotionEvent.ACTION_SCROLL:
                 CallbackBridge.sendScroll(
-                        event.getAxisValue(MotionEvent.AXIS_HSCROLL),
-                        event.getAxisValue(MotionEvent.AXIS_VSCROLL)
+                        LauncherPreferences.PREF_SWAP_TOUCHPAD_AXES
+                                ? event.getAxisValue(MotionEvent.AXIS_VSCROLL)
+                                : event.getAxisValue(MotionEvent.AXIS_HSCROLL),
+                        LauncherPreferences.PREF_SWAP_TOUCHPAD_AXES
+                                ? event.getAxisValue(MotionEvent.AXIS_HSCROLL)
+                                : event.getAxisValue(MotionEvent.AXIS_VSCROLL)
                 );
                 return true;
             case MotionEvent.ACTION_UP:

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -42,6 +42,7 @@ public class LauncherPreferences {
     public static String PREF_DEFAULT_RUNTIME;
     public static boolean PREF_SUSTAINED_PERFORMANCE = false;
     public static boolean PREF_VIRTUAL_MOUSE_START = false;
+    public static boolean PREF_SWAP_TOUCHPAD_AXES = false;
     public static boolean PREF_USE_ALTERNATE_SURFACE = true;
     public static boolean PREF_JAVA_SANDBOX = true;
     public static float PREF_SCALE_FACTOR = 1f;
@@ -97,6 +98,7 @@ public class LauncherPreferences {
         PREF_CUSTOM_JAVA_ARGS = DEFAULT_PREF.getString("javaArgs", "");
         PREF_SUSTAINED_PERFORMANCE = DEFAULT_PREF.getBoolean("sustainedPerformance", isDevicePowerful);
         PREF_VIRTUAL_MOUSE_START = DEFAULT_PREF.getBoolean("mouse_start", false);
+        PREF_SWAP_TOUCHPAD_AXES = DEFAULT_PREF.getBoolean("swap_touchpad_axes", false);
         PREF_USE_ALTERNATE_SURFACE = DEFAULT_PREF.getBoolean("alternate_surface", isDevicePowerful);
         PREF_JAVA_SANDBOX = DEFAULT_PREF.getBoolean("java_sandbox", true);
         PREF_SCALE_FACTOR = DEFAULT_PREF.getInt("resolutionRatio", findBestResolution(ctx, isDevicePowerful))/100f;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/MCOptionUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/MCOptionUtils.java
@@ -119,7 +119,14 @@ public class MCOptionUtils {
     /** @return The stored Minecraft GUI scale, also auto-computed if on auto-mode or improper setting */
     public static int getMcScale() {
         String str = MCOptionUtils.get("guiScale");
-        int guiScale = (str == null ? 0 :Integer.parseInt(str));
+        int guiScale = 0;
+        if(str != null) {
+            try {
+                guiScale = Integer.parseInt(str.trim());
+            } catch (NumberFormatException e) {
+                guiScale = 0;
+            }
+        }
 
         int scale = Math.max(Math.min(windowWidth / 320, windowHeight / 240), 1);
         if(scale < guiScale || guiScale == 0){

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -196,6 +196,8 @@
 
     <string name="preference_mouse_start_title">Start with virtual mouse on</string>
     <string name="preference_mouse_start_description">The virtual mouse appears at startup when this option is on.</string>
+    <string name="preference_swap_touchpad_axes_title">Swap touchpad axes</string>
+    <string name="preference_swap_touchpad_axes_description">Fixes a camera that moves the wrong way on keyboards with built-in touchpads.</string>
     <string name="preference_video_title">Video and renderer</string>
     <string name="preference_video_description">Resolution, renderer and performance</string>
     <string name="preference_control_title">Control customization</string>

--- a/app_pojavlauncher/src/main/res/xml/pref_control.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_control.xml
@@ -99,6 +99,11 @@
             android:title="@string/preference_mouse_start_title"
             android:summary="@string/preference_mouse_start_description"
             android:icon="@drawable/ic_px_virtual_mouse"/>
+        <SwitchPreference
+            android:key="swap_touchpad_axes"
+            android:title="@string/preference_swap_touchpad_axes_title"
+            android:summary="@string/preference_swap_touchpad_axes_description"
+            android:icon="@drawable/ic_px_switch_arrows_x"/>
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Combining arguments could index past the end of the game args array when a duplicate flag was the last entry, crashing the launch with an ArrayIndexOutOfBoundsException.