### PR TITLE
Allow typing with controlmap buttons

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
@@ -63,6 +63,7 @@ public class ControlData {
     public boolean isSwipeable;
     public boolean displayInGame;
     public boolean displayInMenu;
+    public String text;
     public String bitmapTag;
     private float width;         //Dp instead of Px now
     private float height;        //Dp instead of Px now
@@ -108,10 +109,10 @@ public class ControlData {
     }
 
     public ControlData(String name, int[] keycodes, String dynamicX, String dynamicY, float width, float height, boolean isToggle) {
-        this(name, keycodes, dynamicX, dynamicY, width, height, isToggle, 1, 0x4D000000, 0xFFFFFFFF, 0, 0, true, true, false, false, null);
+        this(name, keycodes, dynamicX, dynamicY, width, height, isToggle, 1, 0x4D000000, 0xFFFFFFFF, 0, 0, true, true, false, false, null, null);
     }
 
-    public ControlData(String name, int[] keycodes, String dynamicX, String dynamicY, float width, float height, boolean isToggle, float opacity, int bgColor, int strokeColor, float strokeWidth, float cornerRadius, boolean displayInGame, boolean displayInMenu, boolean isSwipable, boolean mousePassthrough, String bitmapTag) {
+    public ControlData(String name, int[] keycodes, String dynamicX, String dynamicY, float width, float height, boolean isToggle, float opacity, int bgColor, int strokeColor, float strokeWidth, float cornerRadius, boolean displayInGame, boolean displayInMenu, boolean isSwipable, boolean mousePassthrough, String bitmapTag, String text) {
         this.name = name;
         this.keycodes = inflateKeycodeArray(keycodes);
         this.dynamicX = dynamicX;
@@ -129,6 +130,7 @@ public class ControlData {
         this.isSwipeable = isSwipable;
         this.passThruEnabled = mousePassthrough;
         this.bitmapTag = bitmapTag;
+        this.text = text;
     }
 
     //Deep copy constructor
@@ -150,7 +152,8 @@ public class ControlData {
                 controlData.displayInMenu,
                 controlData.isSwipeable,
                 controlData.passThruEnabled,
-                controlData.bitmapTag
+                controlData.bitmapTag,
+                controlData.text
         );
     }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -217,6 +217,8 @@ public class ControlButton extends TextView implements ControlInterface {
                 sendSpecialKey(keycode, isDown);
             }
         }
+        if(isDown && mProperties.text != null)
+            PLATFORM.sendBulkUnicodeEvent(mProperties.text, CallbackBridge.getCurrentMods());
     }
 
     private void sendSpecialKey(int keycode, boolean isDown){

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/handleview/EditControlSideDialog.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/handleview/EditControlSideDialog.java
@@ -62,7 +62,7 @@ public class EditControlSideDialog extends SideDialogView {
             internalChanges = false;
         }
     };
-    private EditText mNameEditText, mWidthEditText, mHeightEditText;
+    private EditText mNameEditText, mWidthEditText, mHeightEditText, mCodepointEditText;
     @SuppressLint("UseSwitchCompatOrMaterialCode")
     private Switch mToggleSwitch, mPassthroughSwitch, mSwipeableSwitch, mForwardLockSwitch, mAbsoluteTrackingSwitch;
     private Spinner mOrientationSpinner;
@@ -77,7 +77,7 @@ public class EditControlSideDialog extends SideDialogView {
     // Decorative textviews
     private TextView mOrientationTextView, mMappingTextView, mNameTextView,
             mCornerRadiusTextView, mVisibilityTextView, mSizeTextview,
-            mSizeXTextView, mStrokeWidthTextView, mColorSelectWarningTextView;
+            mSizeXTextView, mStrokeWidthTextView, mColorSelectWarningTextView, mCodepointTextView;
 
     // Color selector related stuff
     private ColorSelector mColorSelector;
@@ -169,6 +169,7 @@ public class EditControlSideDialog extends SideDialogView {
         mNameEditText.setText(data.name);
         mWidthEditText.setText(String.valueOf(data.getWidth()));
         mHeightEditText.setText(String.valueOf(data.getHeight()));
+        mCodepointEditText.setText(data.text);
 
         mAlphaSeekbar.setProgress((int) (data.opacity * 100));
         mStrokeWidthSeekbar.setProgress((int) data.strokeWidth * 10);
@@ -224,6 +225,9 @@ public class EditControlSideDialog extends SideDialogView {
         mSwipeableSwitch.setVisibility(View.GONE);
         mPassthroughSwitch.setVisibility(View.GONE);
         mToggleSwitch.setVisibility(View.GONE);
+
+        mCodepointTextView.setVisibility(View.GONE);
+        mCodepointEditText.setVisibility(View.GONE);
     }
 
     /**
@@ -256,6 +260,9 @@ public class EditControlSideDialog extends SideDialogView {
         mAbsoluteTrackingSwitch.setChecked(data.absolute);
 
         mSelectBackgroundBitmap.setVisibility(GONE);
+
+        mCodepointTextView.setVisibility(View.GONE);
+        mCodepointEditText.setVisibility(View.GONE);
     }
 
     /**
@@ -355,6 +362,8 @@ public class EditControlSideDialog extends SideDialogView {
         mCornerRadiusPercentTextView = mDialogContent.findViewById(R.id.editCornerRadius_textView_percent);
         mDisplayInGameCheckbox = mDialogContent.findViewById(R.id.visibility_game_checkbox);
         mDisplayInMenuCheckbox = mDialogContent.findViewById(R.id.visibility_menu_checkbox);
+        mCodepointTextView = mDialogContent.findViewById(R.id.editCodepoint_textview);
+        mCodepointEditText = mDialogContent.findViewById(R.id.editCodepoint_edittext);
 
         //Decorative stuff
         mMappingTextView = mDialogContent.findViewById(R.id.editMapping_textView);
@@ -390,6 +399,11 @@ public class EditControlSideDialog extends SideDialogView {
             // Cheap and unoptimized, doesn't break the abstraction layer
             mCurrentlyEditedButton.setProperties(mCurrentlyEditedButton.getProperties(), false);
         });
+
+        mCodepointEditText.addTextChangedListener(((SimpleTextWatcher) s -> {
+            mCurrentlyEditedButton.getProperties().text = s.toString();
+            mCurrentlyEditedButton.setProperties(mCurrentlyEditedButton.getProperties(), false);
+        }));
 
         mWidthEditText.addTextChangedListener((SimpleTextWatcher) s -> {
             if (internalChanges) return;

--- a/app_pojavlauncher/src/main/res/layout/dialog_control_button_setting.xml
+++ b/app_pojavlauncher/src/main/res/layout/dialog_control_button_setting.xml
@@ -255,6 +255,31 @@
 
         tools:text="HELLO" />
 
+    <TextView
+        android:id="@+id/editCodepoint_textview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2.60dp"
+        android:gravity="center"
+        android:text="Chat symbol"
+
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/mapping_3_textview"
+        />
+
+    <EditText
+        android:id="@+id/editCodepoint_edittext"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:hint="A character to type"
+        android:imeOptions="flagNoExtractUi"
+        android:maxLength="1"
+
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/editCodepoint_textview" />
+
+
 
     <!-- ORIENTATION SECTION -->
     <TextView
@@ -267,7 +292,9 @@
         android:text="@string/customctrl_orientation"
 
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/mapping_3_textview" />
+        app:layout_constraintTop_toBottomOf="@+id/editCodepoint_edittext"
+        />
+
 
     <Spinner
         android:id="@+id/editOrientation_spinner"


### PR DESCRIPTION
Allows typing text in chat and other text fields using on-screen control buttons. This feature is supported only with generic buttons, drawer/joystick are unchanged.

To type a character button needs a separate "codepoint" text defined in its settings. I thought of making this process automatic by autoconverting keycodes into codepoints, but that won't support keyboard layouts and wiring them up is too complicated, ugh. Maybe someone else will do this.

This codepoint text is restricted to the length of a single symbol. Typing full text is possible, but it can be considered unfair as it's basically a macro which are disallowed on some servers.

This was present in my `stage/sdl` branch for a while uncommited and I've accidentally lost it after a `git clean`, ugh. Restored with IDEA local history.

Making this draft, as I haven't completed the UI/UX side of the button and haven't talked with @artdeell about this feature.