### PR TITLE
Rename instance root directory along with its name if possible

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/InstanceEditorFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/InstanceEditorFragment.java
@@ -198,9 +198,9 @@ public class InstanceEditorFragment extends Fragment implements CropperUtils.Cro
         //First, check for potential issues in the inputs
         mInstance.versionId = mDefaultVersion.getText().toString();
         mInstance.controlLayout = mDefaultControl.getText().toString();
-        mInstance.name = mDefaultName.getText().toString();
         mInstance.jvmArgs = mDefaultJvmArgument.getText().toString();
 
+        String newName = mDefaultName.getText().toString();
         if(mInstance.controlLayout.isEmpty()) mInstance.controlLayout = null;
         if(mInstance.jvmArgs.isEmpty()) mInstance.jvmArgs = null;
 
@@ -212,8 +212,11 @@ public class InstanceEditorFragment extends Fragment implements CropperUtils.Cro
         else mInstance.renderer = mRenderNames.get(mDefaultRenderer.getSelectedItemPosition());
 
         try {
+            if(!mInstance.name.equals(newName))
+                Instances.renameInstanceDirectory(mInstance, newName);
+            mInstance.name = newName;
             mInstance.write();
-        }catch (IOException e) {
+        }catch (Exception e) {
             Tools.showErrorRemote(e);
         }
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/instances/Instances.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/instances/Instances.java
@@ -1,5 +1,7 @@
 package net.kdt.pojavlaunch.instances;
 
+import android.util.Log;
+
 import com.google.gson.JsonSyntaxException;
 
 import net.kdt.pojavlaunch.Tools;
@@ -44,6 +46,8 @@ public class Instances {
     private static File selectedInstanceLocation() {
         String directoryName = LauncherPreferences.DEFAULT_PREF.getString(LauncherPreferences.PREF_KEY_CURRENT_INSTANCE, "");
         File instanceRoot = new File(sInstancePath, directoryName);
+        if(!instanceRoot.exists())
+            Log.e("Instances", "New instance dir doesn't exist!");
         if(!metadataLocation(instanceRoot).exists()) return null;
         return instanceRoot;
     }
@@ -189,5 +193,30 @@ public class Instances {
         if(instance == null) return null;
         instance.sanitize();
         return instance;
+    }
+
+    /**
+     * Rename the provided instance directory. This will apply the new name only if it's unique.
+     * If no name provided - using bare UUID. If a name conflict - newName as prefix + UUID.
+     * @param instance Instance
+     * @param newName New instance name
+     */
+    public static void renameInstanceDirectory(Instance instance, String newName) {
+        if(newName == null) return;
+        if(newName.trim().isEmpty())
+            newName = String.valueOf(UUID.randomUUID());
+        newName = newName
+                .replace('\\', '-')
+                .replace('\0', '-')
+                .replace(' ', '-');
+        File targetDirectory = new File(sInstancePath, newName);
+        if(targetDirectory.exists())
+            targetDirectory = findNewInstanceRoot(newName);
+        String oldName = instance.mInstanceRoot.getName();
+        if(!instance.mInstanceRoot.renameTo(targetDirectory))
+            throw new RuntimeException("Failed to rename instance!");
+        instance.mInstanceRoot = targetDirectory;
+        if(oldName.equals(LauncherPreferences.DEFAULT_PREF.getString(LauncherPreferences.PREF_KEY_CURRENT_INSTANCE, "")))
+            setSelectedInstance(instance);
     }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/instances/Instances.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/instances/Instances.java
@@ -205,10 +205,8 @@ public class Instances {
         if(newName == null) return;
         if(newName.trim().isEmpty())
             newName = String.valueOf(UUID.randomUUID());
-        newName = newName
-                .replace('\\', '-')
-                .replace('\0', '-')
-                .replace(' ', '-');
+        else
+            newName = FileUtils.escapeFileName(newName);
         File targetDirectory = new File(sInstancePath, newName);
         if(targetDirectory.exists())
             targetDirectory = findNewInstanceRoot(newName);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/ModpackInstaller.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/ModpackInstaller.java
@@ -11,6 +11,7 @@ import net.kdt.pojavlaunch.modloaders.modpacks.imagecache.ModIconCache;
 import net.kdt.pojavlaunch.modloaders.modpacks.models.ModDetail;
 import net.kdt.pojavlaunch.progresskeeper.DownloaderProgressWrapper;
 import net.kdt.pojavlaunch.utils.DownloadUtils;
+import net.kdt.pojavlaunch.utils.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -59,8 +60,7 @@ public class ModpackInstaller {
     public static ModLoader downloadModpack(ModDetail modDetail, int selectedVersion, InstallFunction installFunction) throws IOException {
         String versionUrl = modDetail.versionUrls[selectedVersion];
         String versionHash = modDetail.versionHashes[selectedVersion];
-        String modpackName = (modDetail.title.toLowerCase(Locale.ROOT) + " " + modDetail.versionNames[selectedVersion])
-                .trim().replaceAll("[\\\\/:*?\"<>| \\t\\n]", "_" );
+        String modpackName = FileUtils.escapeFileName(modDetail.title.toLowerCase(Locale.ROOT) + " " + modDetail.versionNames[selectedVersion]);
         String name = modDetail.title;
         String icon = modDetail.getIconCacheTag();
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/FileUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/FileUtils.java
@@ -83,4 +83,8 @@ public class FileUtils {
         if(parentFile == null) throw new IOException("targetFile does not have a parent");
         ensureDirectory(parentFile);
     }
+
+    public static String escapeFileName(String name){
+        return name.trim().replaceAll("[\\\\/:*?\"<>| \\t\\n]", "_");
+    }
 }


### PR DESCRIPTION
Any instance rename (unless the name wasn't changed) will now rename instance root as well. This will massively improve resource installation experience as the user can now give a custom name to instance and easily look it up in the instances directory.

On rename, if the target directory already exists - a UUID is appended to its name like it's done with custom name instances already. If the name is empty - the instance directory will receive a random UUID name.

Not tested much, not marking as draft though.
