### PR TITLE
Fix[jre_launcher]: detach main thread before tearing down

### DIFF
--- a/app_pojavlauncher/src/main/jni/jre_launcher/jre_launcher.c
+++ b/app_pojavlauncher/src/main/jni/jre_launcher/jre_launcher.c
@@ -220,6 +220,7 @@ Java_net_kdt_pojavlaunch_utils_jre_JavaRunner_nativeLoadJVM(JNIEnv *env, jclass 
     (*env)->ReleaseStringUTFChars(env, mainClass, mainClassNameBuf);
 
     bool main_result = executeMain(vm_env, mainClassName, vm_appArgs);
+    (*java_vm.vm)->DetachCurrentThread(java_vm.vm);
     (*java_vm.vm)->DestroyJavaVM(java_vm.vm);
     unloadJavaVM(&java_vm);
     if(!main_result) {


### PR DESCRIPTION
Fixes Ixeris deadlock on shutdown because its Render thread was waiting on JVM main thread which was also waiting for all threads to shutdown. This PR instead makes JVM main thread die safely before destroying the JVM.