### PR TITLE
Fix running Babric

### DIFF
--- a/app_pojavlauncher/src/main/assets/substitutions.json
+++ b/app_pojavlauncher/src/main/assets/substitutions.json
@@ -1977,6 +1977,9 @@
     "org.lwjgl:lwjgl:3.4.1:unsafe": "org.lwjgl:lwjgl:3.4.1",
     "org.lwjgl.lwjgl:lwjgl:2.9.4+legacyfabric.17": "org.lwjgl.lwjgl:lwjgl:2.9.4-glfw",
     "org.lwjgl.lwjgl:lwjgl_util:2.9.4+legacyfabric.17": "org.lwjgl.lwjgl:lwjgl_util:2.9.4-glfw",
-    "org.lwjgl.lwjgl:lwjgl-platform:2.9.4+legacyfabric.17": "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-glfw"
+    "org.lwjgl.lwjgl:lwjgl-platform:2.9.4+legacyfabric.17": "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-glfw",
+    "org.lwjgl.lwjgl:lwjgl:2.9.4-babric.1": "org.lwjgl.lwjgl:lwjgl:2.9.4-glfw",
+    "org.lwjgl.lwjgl:lwjgl_util:2.9.4-babric.1": "org.lwjgl.lwjgl:lwjgl_util:2.9.4-glfw",
+    "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-babric.1": "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-glfw"
   }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/tasks/MoJsonDownloader.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/tasks/MoJsonDownloader.java
@@ -388,6 +388,13 @@ public class MoJsonDownloader extends Downloader {
             if (mAllLibraries.containsKey(libraryTrimmedName)) {
                 mAllLibraries.remove(libraryTrimmedName);
             }
+
+            // If the lib list has both asm-all and normal asm, something is either terribly wrong
+            // or it's just babric. Let's hope for the latter
+            if(libraryTrimmedName.equals("org.ow2.asm:asm")){
+                mAllLibraries.remove("org.ow2.asm:asm-all");
+            }
+
             mAllLibraries.put(libraryTrimmedName, dependentLibrary);
         }
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
@@ -270,6 +270,7 @@ public class GameRunner {
         }
         javaArgList.add("-Dorg.lwjgl.opengl.libname=libGLMojo.so");
         javaArgList.add("-Dorg.lwjgl.freetype.libname="+ Tools.NATIVE_LIB_DIR+"/libfreetype.so");
+        javaArgList.add("-Dorg.lwjgl.librarypath=" + Tools.DIR_CACHE + "/natives/" + versionId);
 
         activity.runOnUiThread(() -> Toast.makeText(activity, activity.getString(R.string.autoram_info_msg,LauncherPreferences.PREF_RAM_ALLOCATION), Toast.LENGTH_SHORT).show());
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
@@ -270,6 +270,7 @@ public class GameRunner {
         }
         javaArgList.add("-Dorg.lwjgl.opengl.libname=libGLMojo.so");
         javaArgList.add("-Dorg.lwjgl.freetype.libname="+ Tools.NATIVE_LIB_DIR+"/libfreetype.so");
+        // Sometimes, the game can extract natives themselves onto this path
         javaArgList.add("-Dorg.lwjgl.librarypath=" + Tools.DIR_CACHE + "/natives/" + versionId);
 
         activity.runOnUiThread(() -> Toast.makeText(activity, activity.getString(R.string.autoram_info_msg,LauncherPreferences.PREF_RAM_ALLOCATION), Toast.LENGTH_SHORT).show());

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
@@ -243,6 +243,8 @@ public class GameRunner {
             String dirPath = versionSpecificNativesDir.getAbsolutePath();
             javaArgList.add("-Djava.library.path="+dirPath+":"+Tools.NATIVE_LIB_DIR);
             javaArgList.add("-Djna.boot.library.path="+dirPath);
+            // Sometimes, the game can extract natives itself onto this path
+            javaArgList.add("-Dorg.lwjgl.librarypath="+dirPath);
         }
 
         File lwjglExtractDir = new File(Tools.DIR_CACHE, "lwjgl_native/"+versionId);
@@ -270,8 +272,6 @@ public class GameRunner {
         }
         javaArgList.add("-Dorg.lwjgl.opengl.libname=libGLMojo.so");
         javaArgList.add("-Dorg.lwjgl.freetype.libname="+ Tools.NATIVE_LIB_DIR+"/libfreetype.so");
-        // Sometimes, the game can extract natives themselves onto this path
-        javaArgList.add("-Dorg.lwjgl.librarypath=" + Tools.DIR_CACHE + "/natives/" + versionId);
 
         activity.runOnUiThread(() -> Toast.makeText(activity, activity.getString(R.string.autoram_info_msg,LauncherPreferences.PREF_RAM_ALLOCATION), Toast.LENGTH_SHORT).show());
 


### PR DESCRIPTION
This PR:
* Adds Babric LWJGL2 mapping
* Restores ASM workaround
* Makes LWJGL search its libs in the app cache.

Babric works, no regressions on other versions.