### PR TITLE
Make Cleanroom boot

### DIFF
--- a/app_pojavlauncher/src/main/assets/substitutions.json
+++ b/app_pojavlauncher/src/main/assets/substitutions.json
@@ -1977,6 +1977,13 @@
     "org.lwjgl:lwjgl:3.4.1:unsafe": "org.lwjgl:lwjgl:3.4.1",
     "org.lwjgl.lwjgl:lwjgl:2.9.4+legacyfabric.17": "org.lwjgl.lwjgl:lwjgl:2.9.4-glfw",
     "org.lwjgl.lwjgl:lwjgl_util:2.9.4+legacyfabric.17": "org.lwjgl.lwjgl:lwjgl_util:2.9.4-glfw",
-    "org.lwjgl.lwjgl:lwjgl-platform:2.9.4+legacyfabric.17": "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-glfw"
+    "org.lwjgl.lwjgl:lwjgl-platform:2.9.4+legacyfabric.17": "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-glfw",
+    "org.lwjgl:lwjgl:3.4.1:natives-linux-arm64": "org.lwjgl:lwjgl:3.4.1",
+    "org.lwjgl:lwjgl-glfw:3.4.1:natives-linux-arm64": "org.lwjgl:lwjgl-glfw:3.4.1",
+    "org.lwjgl:lwjgl-jemalloc:3.4.1:natives-linux-arm64": "org.lwjgl:lwjgl-jemalloc:3.4.1",
+    "org.lwjgl:lwjgl-openal:3.4.1:natives-linux-arm64": "org.lwjgl:lwjgl-openal:3.4.1",
+    "org.lwjgl:lwjgl-opengl:3.4.1:natives-linux-arm64": "org.lwjgl:lwjgl-opengl:3.4.1",
+    "org.lwjgl:lwjgl-stb:3.4.1:natives-linux-arm64": "org.lwjgl:lwjgl-stb:3.4.1",
+    "org.lwjgl:lwjgl-tinyfd:3.4.1:natives-linux-arm64": "org.lwjgl:lwjgl-tinyfd:3.4.1"
   }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
@@ -182,7 +182,7 @@ public class GameRunner {
         }
 
         // Switch renderer to LTW when running 1.21.5
-        if(!isGl4esCompatible(versionInfo) && isGl4es) {
+        if(!versionId.contains("Cleanroom") && !isGl4esCompatible(versionInfo) && isGl4es) {
             rendererName = switchLtw(ltwSupported, instance, activity, R.string.compat_version_not_supported);
         }
         RendererCompatUtil.releaseRenderersCache();


### PR DESCRIPTION
It didn't boot because its json declares Linux ARM64 natives. The launcher did not skip these libraries and did put them onto library path causing LWJGL to load a glibc library.

This PR remaps these ARM64 libs back to original libs (unsure if this is a good solution) and additionally guards GL4ES/LTW switch from triggering on Cleanroom versions (its JSON confuses the launcher and makes it believe the version released after 1.21.5)