### PR TITLE
Feat[instances]: store instance source/type as InstanceHint

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/FabriclikeInstallFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/FabriclikeInstallFragment.java
@@ -22,6 +22,7 @@ import net.kdt.pojavlaunch.PojavApplication;
 import git.artdeell.mojo.R;
 import net.kdt.pojavlaunch.Tools;
 import net.kdt.pojavlaunch.extra.ExtraCore;
+import net.kdt.pojavlaunch.instances.InstanceHint;
 import net.kdt.pojavlaunch.instances.Instances;
 import net.kdt.pojavlaunch.modloaders.FabriclikeUtils;
 import net.kdt.pojavlaunch.modloaders.FabricVersion;
@@ -118,6 +119,7 @@ public abstract class FabriclikeInstallFragment extends Fragment implements Modl
                 i.name = mFabriclikeUtils.getName();
                 i.icon = mFabriclikeUtils.getIconName();
                 i.versionId = versionId;
+                i.instanceHint = mFabriclikeUtils.getType();
             }, versionId);
             getListenerProxy().onDownloadFinished(null);
         }catch (IOException e) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ForgelikeInstallFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ForgelikeInstallFragment.java
@@ -50,6 +50,7 @@ public abstract class ForgelikeInstallFragment extends ModVersionListFragment<Li
                 instance.name = mUtils.getName();
                 instance.icon = mUtils.getIconName();
                 instance.installer = instanceInstaller;
+                instance.instanceHint = mUtils.getType();
             }, selectedVersion);
             ProgressLayout.clearProgress(ProgressLayout.INSTALL_MODPACK);
             instanceInstaller.start();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/OptiFineInstallFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/OptiFineInstallFragment.java
@@ -8,6 +8,7 @@ import com.kdt.mcgui.ProgressLayout;
 
 import git.artdeell.mojo.R;
 
+import net.kdt.pojavlaunch.instances.InstanceHint;
 import net.kdt.pojavlaunch.instances.InstanceInstaller;
 import net.kdt.pojavlaunch.instances.Instances;
 import net.kdt.pojavlaunch.modloaders.ModloaderListenerProxy;
@@ -51,6 +52,7 @@ public class OptiFineInstallFragment extends ModVersionListFragment<OptiFineUtil
                 instance.name = "OptiFine";
                 instance.installer = instanceInstaller;
                 instance.sharedData = true;
+                instance.instanceHint = InstanceHint.OPTIFINE;
             }, "OptiFine");
             ProgressLayout.clearProgress(ProgressLayout.INSTALL_MODPACK);
             instanceInstaller.start();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/instances/Instance.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/instances/Instance.java
@@ -29,6 +29,8 @@ public class Instance extends DisplayInstance {
     public String controlLayout;
     public boolean sharedData;
 
+    public InstanceHint instanceHint;
+
     protected Instance() {
     }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/instances/InstanceHint.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/instances/InstanceHint.java
@@ -1,0 +1,28 @@
+package net.kdt.pojavlaunch.instances;
+
+import net.kdt.pojavlaunch.modloaders.modpacks.api.ModLoader;
+
+public enum InstanceHint {
+    VANILLA(false),
+    OPTIFINE(false),
+    FABRIC(true),
+    QUILT(true),
+    LEGACY_FABRIC(true),
+    FORGE(true),
+    NEOFORGE(true),
+    BTA(true);
+    public final boolean immutable;
+    InstanceHint(boolean immutable){
+        this.immutable = immutable;
+    }
+    public static InstanceHint fromModLoader(ModLoader e){
+        switch(e.modLoaderType){
+            case ModLoader.MOD_LOADER_FABRIC: return InstanceHint.FABRIC;
+            case ModLoader.MOD_LOADER_QUILT: return InstanceHint.QUILT;
+            case ModLoader.MOD_LOADER_LEGACY_FABRIC: return InstanceHint.LEGACY_FABRIC;
+            case ModLoader.MOD_LOADER_FORGE: return InstanceHint.FORGE;
+            case ModLoader.MOD_LOADER_NEOFORGE: return InstanceHint.NEOFORGE;
+            default: return InstanceHint.VANILLA;
+        }
+    }
+}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/instances/Instances.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/instances/Instances.java
@@ -143,6 +143,7 @@ public class Instances {
         internalCreateInstance((instance)-> {
             instance.sharedData = true;
             instance.versionId = "1.12.2";
+            instance.instanceHint = InstanceHint.VANILLA;
         }, null);
     }
 
@@ -154,6 +155,7 @@ public class Instances {
         return createInstance((instance)-> {
             instance.sharedData = true;
             instance.versionId = Instance.VERSION_LATEST_RELEASE;
+            instance.instanceHint = InstanceHint.VANILLA;
         }, null);
     }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/BTADownloadTask.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/BTADownloadTask.java
@@ -9,6 +9,7 @@ import com.kdt.mcgui.ProgressLayout;
 import git.artdeell.mojo.R;
 import net.kdt.pojavlaunch.Tools;
 import net.kdt.pojavlaunch.instances.Instance;
+import net.kdt.pojavlaunch.instances.InstanceHint;
 import net.kdt.pojavlaunch.instances.Instances;
 import net.kdt.pojavlaunch.progresskeeper.ProgressKeeper;
 import net.kdt.pojavlaunch.utils.FileUtils;
@@ -69,6 +70,7 @@ public class BTADownloadTask implements Runnable {
         Instance instance = Instances.createInstance(i -> {
             i.versionId = btaVersionId;
             i.name = "Better than Adventure!";
+            i.instanceHint = InstanceHint.BTA;
         }, "BTA-"+btaVersionId);
         tryDownloadIcon(instance);
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/FabriclikeUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/FabriclikeUtils.java
@@ -3,6 +3,8 @@ package net.kdt.pojavlaunch.modloaders;
 import com.google.gson.JsonSyntaxException;
 
 import net.kdt.pojavlaunch.Tools;
+import net.kdt.pojavlaunch.instances.InstanceHint;
+import net.kdt.pojavlaunch.modloaders.modpacks.api.ModLoader;
 import net.kdt.pojavlaunch.utils.DownloadUtils;
 import net.kdt.pojavlaunch.utils.FileUtils;
 
@@ -17,9 +19,9 @@ import java.net.URLEncoder;
 
 public class FabriclikeUtils {
 
-    public static final FabriclikeUtils FABRIC_UTILS = new FabriclikeUtils("https://meta.fabricmc.net/v2", "fabric", "Fabric", "fabric");
-    public static final FabriclikeUtils QUILT_UTILS = new FabriclikeUtils("https://meta.quiltmc.org/v3", "quilt", "Quilt", "quilt");
-    public static final FabriclikeUtils LEGACY_FABRIC_UTILS = new FabriclikeUtils("https://meta.legacyfabric.net/v2", "legacy_fabric", "Legacy Fabric", "fabric");
+    public static final FabriclikeUtils FABRIC_UTILS = new FabriclikeUtils("https://meta.fabricmc.net/v2", "fabric", "Fabric", "fabric", InstanceHint.FABRIC);
+    public static final FabriclikeUtils QUILT_UTILS = new FabriclikeUtils("https://meta.quiltmc.org/v3", "quilt", "Quilt", "quilt", InstanceHint.QUILT);
+    public static final FabriclikeUtils LEGACY_FABRIC_UTILS = new FabriclikeUtils("https://meta.legacyfabric.net/v2", "legacy_fabric", "Legacy Fabric", "fabric", InstanceHint.LEGACY_FABRIC);
     private static final String LOADER_METADATA_URL = "%s/versions/loader/%s";
     private static final String GAME_METADATA_URL = "%s/versions/game";
 
@@ -29,12 +31,14 @@ public class FabriclikeUtils {
     private final String mCachePrefix;
     private final String mName;
     private final String mIconName;
+    private final InstanceHint mType;
 
-    private FabriclikeUtils(String mApiUrl, String cachePrefix, String mName, String iconName) {
+    private FabriclikeUtils(String mApiUrl, String cachePrefix, String mName, String iconName, InstanceHint type) {
         this.mApiUrl = mApiUrl;
         this.mCachePrefix = cachePrefix;
         this.mIconName = iconName;
         this.mName = mName;
+        this.mType = type;
     }
 
     public FabricVersion[] downloadGameVersions() throws IOException{
@@ -78,6 +82,10 @@ public class FabriclikeUtils {
     }
     public String getIconName() {
         return mIconName;
+    }
+
+    public InstanceHint getType() {
+        return mType;
     }
 
     public String install(String gameVersion, String loaderVersion) throws IOException {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/ForgelikeUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/ForgelikeUtils.java
@@ -3,6 +3,7 @@ package net.kdt.pojavlaunch.modloaders;
 import android.util.Log;
 
 import net.kdt.pojavlaunch.Tools;
+import net.kdt.pojavlaunch.instances.InstanceHint;
 import net.kdt.pojavlaunch.instances.InstanceInstaller;
 import net.kdt.pojavlaunch.utils.DownloadUtils;
 
@@ -29,8 +30,9 @@ public abstract class ForgelikeUtils {
     private final String mMetadataUrl;
     private final String mInstallerUrl;
     private final boolean mVersionOrderInversed;
+    private final InstanceHint mType;
 
-    private ForgelikeUtils(String name, String cachePrefix, String iconName, String versionResolver, String metadataUrl, String installerUrl, boolean versionOrderInversed) {
+    private ForgelikeUtils(String name, String cachePrefix, String iconName, String versionResolver, String metadataUrl, String installerUrl, boolean versionOrderInversed, InstanceHint type) {
         this.mName = name;
         this.mCachePrefix = cachePrefix;
         this.mIconName = iconName;
@@ -38,6 +40,7 @@ public abstract class ForgelikeUtils {
         this.mMetadataUrl = metadataUrl;
         this.mInstallerUrl = installerUrl;
         this.mVersionOrderInversed = versionOrderInversed;
+        this.mType = type;
     }
 
     public List<String> downloadVersions() throws IOException {
@@ -112,6 +115,10 @@ public abstract class ForgelikeUtils {
         return mVersionOrderInversed;
     }
 
+    public InstanceHint getType() {
+        return mType;
+    }
+
     private static String getMcVersionForNeoVersion(String neoVersion) {
         // I feel like it's necessary to explain the NeoForge versioning format
         // basically, what it does is it trims the major version from minecrafts version
@@ -137,7 +144,8 @@ public abstract class ForgelikeUtils {
                     "Forge", "forge", "forge", "%1$s-%2$s",
                     "https://maven.minecraftforge.net/net/minecraftforge/forge/maven-metadata.xml",
                     "https://maven.minecraftforge.net/net/minecraftforge/forge/%1$s/forge-%1$s-installer.jar",
-                    false
+                    false,
+                    InstanceHint.FORGE
             );
         }
 
@@ -159,7 +167,8 @@ public abstract class ForgelikeUtils {
                     "NeoForge", "neoforge", "neoforge", "%2$s",
                     "https://maven.neoforged.net/releases/net/neoforged/neoforge/maven-metadata.xml",
                     "https://maven.neoforged.net/releases/net/neoforged/neoforge/%1$s/neoforge-%1$s-installer.jar",
-                    true
+                    true,
+                    InstanceHint.NEOFORGE
             );
         }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/ModpackInstaller.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/ModpackInstaller.java
@@ -4,6 +4,7 @@ import com.kdt.mcgui.ProgressLayout;
 
 import git.artdeell.mojo.R;
 import net.kdt.pojavlaunch.Tools;
+import net.kdt.pojavlaunch.instances.InstanceHint;
 import net.kdt.pojavlaunch.instances.InstanceInstaller;
 import net.kdt.pojavlaunch.instances.Instances;
 import net.kdt.pojavlaunch.instances.Instance;
@@ -29,6 +30,8 @@ public class ModpackInstaller {
             modLoaderInfo = installFunction.installModpack(modpackFile, instance.getGameDirectory());
 
             if(modLoaderInfo == null) throw new IOException("Unknown modpack mod loader information");
+
+            instance.instanceHint = InstanceHint.fromModLoader(modLoaderInfo);
 
             if(modLoaderInfo.requiresGuiInstallation()) {
                 InstanceInstaller instanceInstaller = modLoaderInfo.createInstaller();


### PR DESCRIPTION
InstanceHint represents an instance type. This type can be either vanilla, any supported mod loader, OptiFine or BTA.

This doesn't change any logic and launcher, but will be very useful in the future:
* For BTA it'd be used to disable the LTW block (as 8.x do run on LTW), tell LTW to expose higher OpenGL version and to automatically pick newer JRE runtime.
* For mod manager it'll be used as a correct replacement for platform - used to prevent installing mods for other modloaders.

Mod manager will additionally block version changing on any non-Vanilla instance.