### PR TITLE
Feat[renderer]: add VirGL (DRM) renderer

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -242,6 +242,7 @@ public class JREUtils {
         boolean preloadVk = true;
         int glesVersion;
         switch (renderer){
+            case "virgl_virtio":
             case "freedreno_kgsl":
                 preloadVk = false;
             case "vulkan_zink":

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/RendererCompatUtil.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/RendererCompatUtil.java
@@ -37,6 +37,12 @@ public class RendererCompatUtil {
         // Current Mesa requires API29+
         boolean deviceCompatibleMesa = SDK_INT >= 29 && new File(Tools.NATIVE_LIB_DIR, "libEGL_mesa.so").exists();
         boolean deviceHasOpenGLES3 = JREUtils.getDetectedVersion() >= 3;
+        PackageManager p = context.getPackageManager();
+        // Enable VirGL if running on ChromeOS or there's virgl used as the system driver
+        // That's because system driver is 99.9% GLES-only, better override with our desktop GL build
+        boolean deviceIsVirgl = p.hasSystemFeature("org.chromium.arc.device_management")
+                || p.hasSystemFeature("org.chromium.arc")
+                || GLInfoUtils.getGlInfo().renderer.contains("virgl");
         // LTW is an optional dependency
         boolean appHasLtw = new File(Tools.NATIVE_LIB_DIR, "libltw.so").exists();
         List<String> rendererIds = new ArrayList<>(defaultRenderers.length);
@@ -48,6 +54,7 @@ public class RendererCompatUtil {
             // freedreno is available only on Adreno GPUs
             if(rendererId.contains("freedreno") && (!(GLInfoUtils.getGlInfo().isAdreno()) || !deviceCompatibleMesa)) continue;
             if(rendererId.contains("ltw") && (!deviceHasOpenGLES3 || !appHasLtw)) continue;
+            if(rendererId.contains("virgl") && (!deviceCompatibleMesa || !deviceIsVirgl)) continue;
             rendererIds.add(rendererId);
             rendererNames.add(defaultRendererNames[i]);
         }

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -36,9 +36,10 @@
     <string name="mcl_setting_title_javaargs">Аргументы запуска JVM</string>
     <string name="mcl_setting_subtitle_javaargs">Осторожно, необдуманное изменение может привести к сбою игры.</string>
     <string name="mcl_setting_category_renderer">Визуализатор</string>
-    <string name="mcl_setting_renderer_gles2_4">Holy GL4ES - все версии до 1.21.4, быстрый</string>
+    <string name="mcl_setting_renderer_gles2_4">Holy GL4ES (OpenGL ES 2) - 1.21.4 и ниже, быстрый</string>
     <string name="mcl_setting_renderer_vulkan_zink">Zink (Vulkan) - все версии, средний</string>
-    <string name="mcl_setting_renderer_freedreno_kgsl">Freedreno - все версии, быстрый, только Adreno</string>
+    <string name="mcl_setting_renderer_freedreno_kgsl">Freedreno (KGSL) - все версии, быстрый, только Adreno</string>
+    <string name="mcl_setting_renderer_virgl_virtio">VirGL (Virtio) - все версии, средний, для ChromeOS</string>
     <string name="mcl_setting_renderer_ltw">LTW (OpenGL ES 3) - 1.17 и выше, быстрый</string>
     <string name="mcl_setting_veroption_release">Релизы</string>
     <string name="mcl_setting_veroption_snapshot">Снапшоты</string>

--- a/app_pojavlauncher/src/main/res/values/headings_array.xml
+++ b/app_pojavlauncher/src/main/res/values/headings_array.xml
@@ -2,9 +2,10 @@
 <resources>
     <string-array name="renderer">
         <item name="1">@string/mcl_setting_renderer_gles2_4</item>
-        <item name="2">@string/mcl_setting_renderer_vulkan_zink</item>
+        <item name="2">@string/mcl_setting_renderer_ltw</item>
         <item name="3">@string/mcl_setting_renderer_freedreno_kgsl</item>
-        <item name="4">@string/mcl_setting_renderer_ltw</item>
+        <item name="4">@string/mcl_setting_renderer_vulkan_zink</item>
+        <item name="5">@string/mcl_setting_renderer_virgl_virtio</item>
     </string-array>
 
     <string-array name="menu_customcontrol">
@@ -37,9 +38,10 @@
     
     <string-array name="renderer_values">
         <item>opengles2</item> <!-- holy-gl4es with OpenGL ES 2/"3" -->
-        <item>vulkan_zink</item> <!-- zink with OpenGL (undef) -->
-        <item>freedreno_kgsl</item> <!-- freedreno gallium driver with OpenGL 4.6 -->
         <item>opengles3_ltw</item> <!-- GL Core on GLES wrapper with GL3/4 -->
+        <item>freedreno_kgsl</item> <!-- freedreno gallium driver with OpenGL 4.6 -->
+        <item>vulkan_zink</item> <!-- zink gallium driver with OpenGL 3.3-4.6 -->
+        <item>virgl_virtio</item> <!-- virgl gallium driver with OpenGL 4.3/4.6 -->
     </string-array>
     <string-array name="download_source_names">
         <item>@string/global_default</item>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -63,10 +63,11 @@
     <string name="mcl_setting_title_javaargs">JVM Launch arguments</string>
     <string name="mcl_setting_subtitle_javaargs">Be careful, this may make game crash if modified without knowledge.</string>
     <string name="mcl_setting_category_renderer">Renderer</string>
-    <string name="mcl_setting_renderer_gles2_4">Holy GL4ES - all versions till 1.21.4, fast</string>
+    <string name="mcl_setting_renderer_gles2_4">Holy GL4ES (OpenGL ES 2) - 1.21.4 and lower, fast</string>
     <string name="mcl_setting_renderer_vulkan_zink">Zink (Vulkan) - all versions, mid</string>
-    <string name="mcl_setting_renderer_freedreno_kgsl">Freedreno - all versions, fast, Adreno-only</string>
-    <string name="mcl_setting_renderer_ltw">LTW (OpenGL ES 3) - 1.17+ only, fast</string>
+    <string name="mcl_setting_renderer_freedreno_kgsl">Freedreno (KGSL) - all versions, fast, Adreno-only</string>
+    <string name="mcl_setting_renderer_virgl_virtio">VirGL (Virtio) - all versions, mid, for ChromeOS</string>
+    <string name="mcl_setting_renderer_ltw">LTW (OpenGL ES 3) - 1.17 and newer, fast</string>
     <string name="mcl_setting_veroption_release">Release</string>
     <string name="mcl_setting_veroption_snapshot">Snapshot</string>
     <string name="mcl_setting_veroption_oldalpha">Old-alpha</string>


### PR DESCRIPTION
Adds a new VirGL renderer definition for devices that use virtio-gpu as their DRM driver. These are generally Chromebooks and using this driver greatly improves the experience due to full OpenGL available with VirGL.

System driver on most x86 Chromebooks ArcVM exposes only OpenGL ES.

Does not support old Pojav VirGL/vtest setup and generally different thing. It might appear too in the future.