### PR TITLE
feat: manual JRE downloads

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/InternalRuntime.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/InternalRuntime.java
@@ -1,0 +1,18 @@
+package net.kdt.pojavlaunch;
+
+public enum InternalRuntime {
+    JRE_8(8, "Internal-8", "components/jre-new"),
+    JRE_17(17, "Internal-17", "components/jre-new"),
+    JRE_21(21, "Internal-21", "components/jre-21"),
+    JRE_25(25, "Internal-25", "components/jre-25");
+
+    public final int majorVersion;
+    public final String name;
+    public final String path;
+
+    InternalRuntime(int majorVersion, String name, String path) {
+        this.majorVersion = majorVersion;
+        this.name = name;
+        this.path = path;
+    }
+}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/NewJREUtil.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/NewJREUtil.java
@@ -75,6 +75,12 @@ public class NewJREUtil {
             this.mSignatureCheckUtil = mSignatureCheckUtil;
         }
 
+        public RuntimeDownloaderVerifier(Map<String, byte[]> signatures, String runtimePath, SignatureCheckUtil mSignatureCheckUtil) {
+            this.mSignatures = signatures;
+            this.mRuntimePath = runtimePath;
+            this.mSignatureCheckUtil = mSignatureCheckUtil;
+        }
+
         public boolean downloadAndVerify(String component, File output, int progressString) throws IOException {
             DownloadUtils.downloadFileMonitored(
                     mRuntimePath + component, output, mDownloadBuffer,
@@ -125,9 +131,9 @@ public class NewJREUtil {
         } finally {
             ProgressLayout.clearProgress(ProgressLayout.UNPACK_RUNTIME);
             // Those files being deleted are on a "i wish" basis
-            if(universalCache != null && universalCache.isFile()) //noinspection ResultOfMethodCallIgnored
+            if(universalCache != null && universalCache.isFile())
                 universalCache.delete();
-            if(platformCache != null && platformCache.isFile()) //noinspection ResultOfMethodCallIgnored
+            if(platformCache != null && platformCache.isFile())
                 platformCache.delete();
         }
     }
@@ -151,7 +157,7 @@ public class NewJREUtil {
 
 
     public static void installNewJreIfNeeded(AssetManager assetManager, JVersionList.Version versionInfo) throws IOException, RuntimeSelectionException {
-        //Now we have the reliable information to check if our runtime settings are good enough
+        // Now we have the reliable information to check if our runtime settings are good enough
         if (versionInfo.javaVersion == null || versionInfo.javaVersion.component.equalsIgnoreCase("jre-legacy")) return;
 
         int gameRequiredVersion = versionInfo.javaVersion.majorVersion;
@@ -165,7 +171,6 @@ public class NewJREUtil {
             InternalRuntime internalRuntime = getInternalRuntime(runtime);
             // If it is, check if updates are available from the APK file
             if(internalRuntime != null) {
-                // Not calling showRuntimeFail on failure here because we did, technically, find the compatible runtime
                 checkInternalRuntime(assetManager, internalRuntime);
             }
             return;
@@ -191,9 +196,9 @@ public class NewJREUtil {
 
         // Perform checks on the picked runtime
         if(selected instanceof Runtime) {
+            Runtime selectedRuntime = (Runtime) selected;
             // If it's an already installed runtime, save its name and check if
             // it's actually an internal one (just in case)
-            Runtime selectedRuntime = (Runtime) selected;
             appropriateRuntime = selectedRuntime.name;
             internalRuntime = getInternalRuntime(selectedRuntime);
         } else if (selected instanceof InternalRuntime) {
@@ -206,6 +211,7 @@ public class NewJREUtil {
 
         // If it turns out the selected runtime is actually an internal one, attempt automatic installation or update
         if(internalRuntime != null) {
+            // Not calling showRuntimeFail on failure here because we did, technically, find the compatible runtime
             checkInternalRuntime(assetManager, internalRuntime);
         }
 
@@ -213,18 +219,71 @@ public class NewJREUtil {
         instance.write();
     }
 
-    private enum InternalRuntime {
+    public enum ExternalRuntime {
+        JRE_8(8, "Internal-8", "components/jre-new"),
         JRE_17(17, "Internal-17", "components/jre-new"),
         JRE_21(21, "Internal-21", "components/jre-21"),
         JRE_25(25, "Internal-25", "components/jre-25");
+
         public final int majorVersion;
         public final String name;
         public final String path;
-        InternalRuntime(int majorVersion, String name, String path) {
+        public boolean isDownloading = false;
+
+        ExternalRuntime(int majorVersion, String name, String path) {
             this.majorVersion = majorVersion;
             this.name = name;
             this.path = path;
         }
+
+        public void downloadRuntime(AssetManager assetManager) throws RuntimeSelectionException {
+            tryDownloadExternalRuntime(assetManager, this);
+        }
     }
 
+    private static void tryDownloadExternalRuntime(AssetManager assetManager, ExternalRuntime externalRuntime) throws RuntimeSelectionException {
+        try {
+            String remoteVersion = DownloadUtils.downloadString(DOWNLOAD_URL + externalRuntime.path + "/version");
+            unpackExternalRuntime(assetManager, externalRuntime, remoteVersion);
+        } catch (IOException e) {
+            throw new RuntimeSelectionException(RuntimeSelectionException.RUNTIME_STATE_INSTALLATION_FAILED, externalRuntime.majorVersion);
+        }
+    }
+
+    private static void unpackExternalRuntime(AssetManager assetManager, ExternalRuntime externalRuntime, String versionSignatures) throws RuntimeSelectionException {
+        Map<String, byte[]> signatures = SignatureCheckUtil.decodeSignatureBundle(versionSignatures);
+        String platformBinFile = "bin-"+archAsString(Tools.DEVICE_ARCHITECTURE)+".tar.xz";
+        if(!signatures.containsKey("universal.tar.xz") || !signatures.containsKey(platformBinFile)) {
+            throw new RuntimeSelectionException(RuntimeSelectionException.RUNTIME_STATE_INSTALLATION_FAILED, externalRuntime.majorVersion);
+        }
+
+        File universalCache = null, platformCache = null;
+        try {
+            SignatureCheckUtil signatureCheckUtil = SignatureCheckUtil.create(assetManager);
+            universalCache = File.createTempFile("jre-install-", "-universal", Tools.DIR_CACHE);
+            platformCache = File.createTempFile("jre-install-", "-platform", Tools.DIR_CACHE);
+
+            String runtimePath = DOWNLOAD_URL + externalRuntime.path + "/";
+            RuntimeDownloaderVerifier verifier = new RuntimeDownloaderVerifier(signatures, runtimePath, signatureCheckUtil);
+
+            if (!verifier.downloadAndVerify("universal.tar.xz", universalCache, R.string.downloading_java_runtime_uni) ||
+                    !verifier.downloadAndVerify(platformBinFile, platformCache, R.string.downloading_java_runtime_platform)) {
+                throw new RuntimeSelectionException(RuntimeSelectionException.RUNTIME_STATE_INSTALLATION_FAILED, externalRuntime.majorVersion);
+            }
+
+            try (FileInputStream universal = new FileInputStream(universalCache); FileInputStream platform = new FileInputStream(platformCache)) {
+                MultiRTUtils.installRuntimeNamedBinpack(universal, platform, externalRuntime.name, versionSignatures);
+                MultiRTUtils.postPrepare(externalRuntime.name);
+                MultiRTUtils.forceReread(externalRuntime.name);
+            }
+        } catch (IOException e) {
+            throw new RuntimeSelectionException(RuntimeSelectionException.RUNTIME_STATE_INSTALLATION_FAILED, externalRuntime.majorVersion);
+        } finally {
+            ProgressLayout.clearProgress(ProgressLayout.UNPACK_RUNTIME);
+            if(universalCache != null && universalCache.isFile())
+                universalCache.delete();
+            if(platformCache != null && platformCache.isFile())
+                platformCache.delete();
+        }
+    }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/multirt/MultiRTConfigDialog.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/multirt/MultiRTConfigDialog.java
@@ -1,6 +1,7 @@
 package net.kdt.pojavlaunch.multirt;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.widget.Button;
@@ -14,6 +15,7 @@ import git.artdeell.mojo.R;
 public class MultiRTConfigDialog {
     private AlertDialog mDialog;
     private RecyclerView mDialogView;
+    private RTRecyclerViewAdapter mAdapter;
 
     /** Show the dialog, refreshes the adapter data before showing it */
     public void show(){
@@ -31,8 +33,11 @@ public class MultiRTConfigDialog {
     public void prepare(Context activity, ActivityResultLauncher<Object> installJvmLauncher) {
         mDialogView = new RecyclerView(activity);
         mDialogView.setLayoutManager(new LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false));
-        RTRecyclerViewAdapter adapter = new RTRecyclerViewAdapter();
-        mDialogView.setAdapter(adapter);
+        mAdapter = new RTRecyclerViewAdapter();
+        if(activity instanceof Activity) {
+            mAdapter.setActivity((Activity) activity);
+        }
+        mDialogView.setAdapter(mAdapter);
 
         mDialog = new AlertDialog.Builder(activity)
                 .setTitle(R.string.multirt_config_title)
@@ -45,8 +50,8 @@ public class MultiRTConfigDialog {
         mDialog.setOnShowListener(dialog -> {
             Button button = ((AlertDialog) dialog).getButton(AlertDialog.BUTTON_NEUTRAL);
             button.setOnClickListener(view -> {
-                boolean isEditing = !adapter.getIsEditing();
-                adapter.setIsEditing(isEditing);
+                boolean isEditing = !mAdapter.getIsEditing();
+                mAdapter.setIsEditing(isEditing);
                 button.setText(isEditing ? R.string.multirt_config_setdefault : R.string.multirt_delete_runtime);
             });
         });

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/multirt/MultiRTUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/multirt/MultiRTUtils.java
@@ -10,6 +10,8 @@ import android.util.Log;
 import com.kdt.mcgui.ProgressLayout;
 
 import git.artdeell.mojo.R;
+import net.kdt.pojavlaunch.Architecture;
+import net.kdt.pojavlaunch.NewJREUtil;
 import net.kdt.pojavlaunch.Tools;
 import net.kdt.pojavlaunch.utils.MathUtils;
 import net.kdt.pojavlaunch.utils.jre.JavaRunner;
@@ -53,6 +55,19 @@ public class MultiRTUtils {
         else throw new RuntimeException("The runtime directory does not exist");
 
         return runtimes;
+    }
+
+    public static List<NewJREUtil.ExternalRuntime> getRuntimesToDownload() {
+        List<NewJREUtil.ExternalRuntime> runtimesToDownload = new ArrayList<>();
+        NewJREUtil.ExternalRuntime[] downloadableRuntimes = NewJREUtil.ExternalRuntime.values();
+
+        for (NewJREUtil.ExternalRuntime downloadableruntime : downloadableRuntimes) {
+            if(getExactJreName(downloadableruntime.majorVersion) == null){
+                if (!(Tools.DEVICE_ARCHITECTURE == Architecture.ARCH_X86 && downloadableruntime.majorVersion >= 21))
+                    runtimesToDownload.add(downloadableruntime);
+            }
+        }
+        return runtimesToDownload;
     }
 
     public static String getExactJreName(int majorVersion) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/multirt/RTRecyclerViewAdapter.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/multirt/RTRecyclerViewAdapter.java
@@ -3,7 +3,9 @@ package net.kdt.pojavlaunch.multirt;
 import static net.kdt.pojavlaunch.PojavApplication.sExecutorService;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Context;
+import android.content.res.AssetManager;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.view.LayoutInflater;
@@ -18,9 +20,11 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.RecyclerView;
 
 import net.kdt.pojavlaunch.Architecture;
+import net.kdt.pojavlaunch.NewJREUtil;
 import git.artdeell.mojo.R;
 import net.kdt.pojavlaunch.Tools;
 import net.kdt.pojavlaunch.prefs.LauncherPreferences;
+import net.kdt.pojavlaunch.utils.jre.RuntimeSelectionException;
 
 import java.io.IOException;
 import java.util.List;
@@ -28,6 +32,12 @@ import java.util.List;
 public class RTRecyclerViewAdapter extends RecyclerView.Adapter<RTRecyclerViewAdapter.RTViewHolder> {
 
     private boolean mIsDeleting = false;
+    private Activity mActivity;
+    private boolean mIsDownloading = false;
+
+    public void setActivity(Activity activity) {
+        mActivity = activity;
+    }
 
     @NonNull
     @Override
@@ -38,13 +48,20 @@ public class RTRecyclerViewAdapter extends RecyclerView.Adapter<RTRecyclerViewAd
 
     @Override
     public void onBindViewHolder(@NonNull RTViewHolder holder, int position) {
-        final List<Runtime> runtimes = MultiRTUtils.getRuntimes();
-        holder.bindRuntime(runtimes.get(position),position);
+        final List<Runtime> installedRuntimes = MultiRTUtils.getRuntimes();
+        final List<NewJREUtil.ExternalRuntime> downloadableRuntimes = MultiRTUtils.getRuntimesToDownload();
+
+        if (position < installedRuntimes.size()) {
+            holder.bindRuntime(installedRuntimes.get(position), position);
+        } else if (position < installedRuntimes.size() + downloadableRuntimes.size()) {
+            int downloadPos = position - installedRuntimes.size();
+            holder.bindDownloadableRuntime(downloadableRuntimes.get(downloadPos), position);
+        }
     }
 
     @Override
     public int getItemCount() {
-        return MultiRTUtils.getRuntimes().size();
+        return MultiRTUtils.getRuntimes().size() + MultiRTUtils.getRuntimesToDownload().size();
     }
 
     public boolean isDefaultRuntime(Runtime rt) {
@@ -77,6 +94,7 @@ public class RTRecyclerViewAdapter extends RecyclerView.Adapter<RTRecyclerViewAd
         final ImageButton mDeleteButton;
         final Context mContext;
         Runtime mCurrentRuntime;
+        NewJREUtil.ExternalRuntime mCurrentDownloadableRuntime;
         int mCurrentPosition;
 
         public RTViewHolder(View itemView) {
@@ -98,6 +116,8 @@ public class RTRecyclerViewAdapter extends RecyclerView.Adapter<RTRecyclerViewAd
                 if(mCurrentRuntime != null) {
                     setDefault(mCurrentRuntime);
                     RTRecyclerViewAdapter.this.notifyDataSetChanged();
+                } else if(mCurrentDownloadableRuntime != null) {
+                    downloadRuntime(mCurrentDownloadableRuntime);
                 }
             });
 
@@ -129,9 +149,42 @@ public class RTRecyclerViewAdapter extends RecyclerView.Adapter<RTRecyclerViewAd
             });
         }
 
+        @SuppressLint("NotifyDataSetChanged")
+        private void downloadRuntime(NewJREUtil.ExternalRuntime runtime) {
+            if(mActivity == null) return;
+            if(mIsDownloading) return;
+
+            mIsDownloading = true;
+            mSetDefaultButton.setEnabled(false);
+            mSetDefaultButton.setText(R.string.global_installing);
+            runtime.isDownloading = true;
+
+            sExecutorService.execute(() -> {
+                try {
+                    AssetManager assetManager = mActivity.getAssets();
+                    runtime.downloadRuntime(assetManager);
+
+                    mSetDefaultButton.post(() -> {
+                        runtime.isDownloading = false;
+                        mIsDownloading = false;
+                        notifyDataSetChanged();
+                    });
+                } catch (RuntimeSelectionException e) {
+                    Tools.showError(mActivity, e);
+                    mSetDefaultButton.post(() -> {
+                        runtime.isDownloading = false;
+                        mIsDownloading = false;
+                        notifyDataSetChanged();
+                    });
+                }
+            });
+        }
+
         public void bindRuntime(Runtime runtime, int pos) {
             mCurrentRuntime = runtime;
+            mCurrentDownloadableRuntime = null;
             mCurrentPosition = pos;
+
             if(runtime.versionString != null && Tools.DEVICE_ARCHITECTURE == Architecture.archAsInt(runtime.arch)) {
                 mJavaVersionTextView.setText(runtime.name
                         .replace(".tar.xz", "")
@@ -157,6 +210,32 @@ public class RTRecyclerViewAdapter extends RecyclerView.Adapter<RTRecyclerViewAd
             mJavaVersionTextView.setText(runtime.name);
             mFullJavaVersionTextView.setTextColor(Color.RED);
             mSetDefaultButton.setVisibility(View.GONE);
+        }
+
+        public void bindDownloadableRuntime(NewJREUtil.ExternalRuntime runtime, int pos) {
+            mCurrentRuntime = null;
+            mCurrentDownloadableRuntime = runtime;
+            mCurrentPosition = pos;
+
+            mJavaVersionTextView.setText(runtime.name
+                    .replace(".tar.xz", "")
+                    .replace("-", " "));
+
+            mFullJavaVersionTextView.setText(R.string.global_not_installed);
+            mFullJavaVersionTextView.setTextColor(mDefaultColors);
+
+            mSetDefaultButton.setVisibility(View.VISIBLE);
+            mDeleteButton.setVisibility(View.GONE);
+
+            if (mIsDownloading || runtime.isDownloading) {
+                mSetDefaultButton.setEnabled(false);
+                mSetDefaultButton.setText(R.string.global_installing);
+                mSetDefaultButton.setAlpha(0.5f);
+            } else {
+                mSetDefaultButton.setEnabled(true);
+                mSetDefaultButton.setText(R.string.global_download);
+                mSetDefaultButton.setAlpha(1.0f);
+            }
         }
 
         private void updateButtonsVisibility(){

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -513,4 +513,8 @@
     <string name="loading_screen_warning">If you are stuck here, the game might have crashed</string>
     <string name="preference_button_transparency">Buttons transparency</string>
     <string name="preference_button_transparency_summary">Changes on-screen buttons transparency</string>
+    <string name="global_not_installed">Not Installed</string>
+    <string name="global_download">Download</string>
+    <string name="global_installing">Installing…</string>
+    <string name="multirt_no_internet">Failed to download, check your internet connection.</string>
 </resources>


### PR DESCRIPTION
[REOPENED] This PR adds manual JRE runtime installation inside the "Runtime Manager". It uses `https://mojolauncher.github.io/jre-download` to download JRE runtimes for specific versions manually. Just click download, and it will start downloading until it gets imported and finished. JRE download through launching still works, but this creates another way to install them if the launching session fails. Feel free to edit the file if you want.