### PR TITLE
Fix[arg_parser]: do not ignore long args with multiple equal signs

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -224,6 +224,10 @@ public class JREUtils {
                     }
                     parsedArguments.add(parsedSubString);
                 }
+                // --a-b= handling (with multiple signs so we don't accidentally remove mandatory args)
+                else if(parsedSubString.startsWith("--") && parsedSubString.indexOf('=') != -1) {
+                    parsedArguments.add(parsedSubString);
+                }
                 else Log.w("JAVA ARGS PARSER", "Removed improper arguments: " + parsedSubString);
             }
         }


### PR DESCRIPTION
Fixes lwjgl3ify if you manually replace all spaces with signs