### PR TITLE
Correctly parse client VM arguments for lwjgl3ify

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
@@ -334,7 +334,7 @@ public class GameRunner {
     private static List<String> getMoJsonJvmArgs(String versionName) {
         JVersionList.Version versionInfo = Tools.getVersionInfo(versionName, true);
         // Parse Forge 1.17+ additional JVM Arguments
-        if (versionInfo.inheritsFrom == null || versionInfo.arguments == null || versionInfo.arguments.jvm == null) {
+        if (versionInfo.arguments == null || versionInfo.arguments.jvm == null) {
             return Collections.emptyList();
         }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/JavaRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/JavaRunner.java
@@ -238,6 +238,12 @@ public class JavaRunner {
                 case "-XX:+UseLargePages":
                     iterator.remove();
                     break;
+                case "-cp":
+                    // remove classpath and the next argument (which is either garbage or pointless classpath definition)
+                    iterator.remove();
+                    iterator.next();
+                    iterator.remove();
+                    break;
                 default:
                     if(arg.startsWith("-Xms") || arg.startsWith("-Xmx") || arg.startsWith("-XX:ActiveProcessorCount")) iterator.remove();
                     if(!hasJavaAgent && arg.startsWith("-javaagent:")) hasJavaAgent = true;


### PR DESCRIPTION
* Skip `-cp` argument as lwjgl3ify explicitly sets it while it's pointless for us;
* Allow client vm args from the json even if no `inheritsFrom` is present. This could nuke even vanilla Mojang client arguments.

With these fixes lwjgl3ify boots without explicitly adding its arguments i.e. out-of-the-box (if you install lwjgl3ify mod as well)