### PR TITLE
Fix[game_runner]: do not override essential args with mojson args

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/jre/GameRunner.java
@@ -5,7 +5,6 @@ import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog.Builder;
 import androidx.appcompat.app.AppCompatActivity;
 
 import net.kdt.pojavlaunch.Architecture;
@@ -264,7 +263,7 @@ public class GameRunner {
 
         addAuthlibInjectorArgs(javaArgList, account);
 
-        javaArgList.addAll(getMoJsonJvmArgs(versionId));
+        mergeMoJsonArgs(javaArgList, getMoJsonJvmArgs(versionId));
 
         javaArgList.addAll(JREUtils.parseJavaArguments(instance.getLaunchArgs()));
 
@@ -329,6 +328,27 @@ public class GameRunner {
         String injectorUrl = account.authType.injectorUrl;
         if(injectorUrl == null) return;
         javaArgList.add("-javaagent:"+Tools.DIR_DATA+"/authlib-injector/authlib-injector.jar="+injectorUrl);
+    }
+
+    // Skip setting essential flags from the version JSON as we already override them
+    private static boolean shouldSkipArg(String arg) {
+        final String[] args = {
+                "-Djava.library.path=",
+                "-Djna.tmpdir=",
+                "-Dorg.lwjgl.system.SharedLibraryExtractPath=",
+                "-Dio.netty.native.workdir="
+        };
+        for(String s : args) {
+            if(arg.startsWith(s)) return true;
+        }
+        return false;
+    }
+
+    private static void mergeMoJsonArgs(List<String> userArgs, List<String> moJsonArgs) {
+        for(String arg : moJsonArgs) {
+            if(shouldSkipArg(arg)) continue;
+            userArgs.add(arg);
+        }
     }
 
     private static List<String> getMoJsonJvmArgs(String versionName) {


### PR DESCRIPTION
Fixes running 26.3 as it has added args we override directly into json (which we now handle) thus breaking them